### PR TITLE
Block .project_team/ additions on main via required status check

### DIFF
--- a/.github/workflows/no-project-team-additions-on-main.yml
+++ b/.github/workflows/no-project-team-additions-on-main.yml
@@ -1,0 +1,29 @@
+name: Block .project_team/ additions on main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Reject PR if it adds or modifies .project_team/ paths
+        run: |
+          set -euo pipefail
+          base="origin/${{ github.event.pull_request.base.ref }}"
+          # --diff-filter=AM = additions or modifications only.
+          # Deletions (cleanup PRs) are allowed.
+          violators=$(git diff --name-only --diff-filter=AM "${base}...HEAD" | grep '^\.project_team/' || true)
+          if [ -n "$violators" ]; then
+            echo "ERROR: This PR adds or modifies .project_team/ paths."
+            echo ".project_team/ is develop-only audit-trail material and must not land on main."
+            echo ""
+            echo "Violating paths:"
+            printf '  %s\n' $violators
+            exit 1
+          fi
+          echo "OK: no .project_team/ additions in this PR."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,15 @@ For live testing by AI agents, run with remote control enabled:
 
 This starts an HTTP server on port 9999 with endpoints for sending messages, taking screenshots, and checking state. See [docs/dev/remote-testing.md](docs/dev/remote-testing.md) for full API documentation.
 
+## Branch policy
+
+- `develop` is the trunk. All work commits land here first.
+- `main` is the public release branch. PRs target `main` from `develop` (or feature branches).
+- `.project_team/` is **develop-only** audit-trail material. PRs to main must not include `.project_team/` paths.
+  - Enforced by `.github/workflows/no-project-team-additions-on-main.yml` (required status check).
+  - The local `block-project-team-on-main` pre-commit hook is a belt-and-suspenders for direct-on-main commits.
+- Cleanup PRs that delete `.project_team/` paths from main are explicitly allowed.
+
 ## Pre-commit Hooks
 
 ```bash
@@ -195,7 +204,7 @@ uv run pre-commit install  # Install hooks (one-time)
 uv run pre-commit run --all-files  # Run manually
 ```
 
-Hooks: ruff (lint + fix), ruff-format, pyright. Run automatically on commit.
+Hooks: ruff (lint + fix), ruff-format, check-added-large-files, pyright, block-project-team-on-main. Run automatically on commit.
 
 ## GitHub
 


### PR DESCRIPTION
## Summary

Adds a GitHub Action that fails any PR to main introducing or modifying `.project_team/` paths. Deletions (cleanup PRs like #35) are explicitly allowed.

The existing `block-project-team-on-main` pre-commit hook only catches direct-on-main commits, not merges from develop -- which is how artifacts have been silently leaking onto main on every project PR. This Action closes that gap.

## Changes

- **New:** `.github/workflows/no-project-team-additions-on-main.yml` -- runs on every PR to main, scans the diff with `git diff --name-only --diff-filter=AM`, fails if any `.project_team/` paths appear.
- **CLAUDE.md:** new "Branch policy" section documenting develop/main split and the enforcement stack (Action + local hook).
- **CLAUDE.md (drive-by):** corrected the pre-commit hook list to match the actual `.pre-commit-config.yaml` -- added `check-added-large-files` and `block-project-team-on-main` which were missing from the docs.

## Enabling the gate

After this PR merges, in GitHub repo settings -> Branch protection rules for `main`:

- Add **"Block .project_team/ additions on main / check"** to the required status checks list.

Once required, the Action cannot be bypassed without admin override.

## Test plan

- [x] YAML parses clean (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Pre-commit `--all-files` passes
- [ ] After merge: confirm the Action runs on the next PR to main and reports the expected pass/fail behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)