### PR TITLE
sync: cherry-pick 9 bug fixes from upstream mrocklin/claudechic

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -1298,6 +1298,27 @@ class ChatApp(App):
             lambda msg, severity: self.notify(msg, severity=severity, timeout=5)
         )
 
+        # Warn on washed-out colors over SSH (COLORTERM rarely propagates,
+        # so Textual falls back to 256-color). Skip locally to avoid nagging
+        # users whose terminal genuinely can't do truecolor.
+        is_ssh = any(
+            os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")
+        )
+        color_system = self.console.color_system
+        log.debug(
+            "color_system=%s TERM=%s COLORTERM=%s SSH=%s",
+            color_system,
+            os.environ.get("TERM"),
+            os.environ.get("COLORTERM"),
+            is_ssh,
+        )
+        if is_ssh and color_system != "truecolor":
+            log.warning(
+                "Colors look washed out? Terminal is %s, not truecolor. "
+                "Try `export COLORTERM=truecolor` on the remote host.",
+                color_system or "unknown",
+            )
+
         # Start CPU sampling profiler + event loop lag monitor
         start_sampler()
         self._monitor_lag_task = create_safe_task(
@@ -1583,6 +1604,18 @@ class ChatApp(App):
             self.exit(
                 message=f"Connection failed: {e}\n\nPlease run `claude /login` to authenticate."
             )
+            return
+        except Exception as e:
+            # Catch-all (e.g. SDK "Control request timeout: initialize") so
+            # the user sees a clean message rather than a crashing traceback.
+            await capture(
+                "error_occurred",
+                error_type=type(e).__name__,
+                error_subtype=str(e)[:200],
+                context="initial_connect",
+            )
+            self.exit(message=f"Connection failed: {e}")
+            return
 
         # Load history if resuming
         if resume:

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -461,6 +461,7 @@ SDK_PASSTHROUGH_COMMANDS = frozenset(
         "/compact",
         "/context",
         "/init",
+        "/ultrareview",  # Cloud-based parallel multi-agent review (Claude Code 2.1.111+)
     }
 )
 

--- a/claudechic/shell_runner.py
+++ b/claudechic/shell_runner.py
@@ -77,7 +77,10 @@ def run_in_pty(
 
         os.close(master_fd)
         proc.wait()
-        return output.decode(errors="replace"), proc.returncode or 0
+        # Strip \r from PTY output (onlcr maps \n to \r\n); Rich's from_ansi
+        # treats bare \r as a cursor-return and collapses lines.
+        decoded = output.decode(errors="replace").replace("\r", "")
+        return decoded, proc.returncode or 0
     except Exception:
         os.close(master_fd)
         raise
@@ -165,7 +168,8 @@ def _run_in_pty_with_cancel(
         os.close(master_fd)
         master_fd = -1
         proc.wait()
-        return output.decode(errors="replace"), proc.returncode or 0, was_cancelled
+        decoded = output.decode(errors="replace").replace("\r", "")
+        return decoded, proc.returncode or 0, was_cancelled
 
     except Exception:
         if slave_fd >= 0:

--- a/claudechic/widgets/content/diff.py
+++ b/claudechic/widgets/content/diff.py
@@ -36,13 +36,25 @@ LIGHT_THEME_STYLES = {
 def _get_cached_lexer(language: str):
     """Cache Pygments lexers to avoid repeated loading (~15% CPU savings)."""
     try:
-        return get_lexer_by_name(language, stripnl=False, ensurenl=True, tabsize=8)
+        return get_lexer_by_name(language, stripnl=False, ensurenl=False)
     except ClassNotFound:
         return None
 
 
 def _highlight_text(text: str, language: str) -> Content:
-    """Syntax highlight text using cached lexer and default HighlightTheme."""
+    """Syntax highlight text using cached lexer and default HighlightTheme.
+
+    Accumulates span positions from token-text lengths rather than trusting
+    the lexer's reported source indices. Some lexers (notably ``markdown``,
+    which delegates fenced code blocks to a sub-lexer) emit indices that
+    reset to 0 inside embedded blocks, so using those indices directly would
+    splat inner-block spans onto the start of the document.
+
+    Safe because the cached lexer is built with ``stripnl=False,
+    ensurenl=False`` (see ``_get_cached_lexer``) and default ``tabsize=0``,
+    and we expand tabs at the diff input — so tokens preserve source text
+    exactly (verified across markdown/python/go/js/rust).
+    """
     if not language:
         return Content(text)
 
@@ -51,19 +63,18 @@ def _highlight_text(text: str, language: str) -> Content:
         return Content(text)
 
     text = "\n".join(text.splitlines())
-    token_start = 0
     spans: list[Span] = []
 
+    pos = 0
     for token_type, token in lexer.get_tokens(text):
-        token_end = token_start + len(token)
         current_type = token_type
         while True:
             if style := HighlightTheme.STYLES.get(current_type):
-                spans.append(Span(token_start, token_end, style))
+                spans.append(Span(pos, pos + len(token), style))
                 break
             if (current_type := current_type.parent) is None:
                 break
-        token_start = token_end
+        pos += len(token)
 
     return Content(text, spans=spans).stylize_before("$text")
 
@@ -217,6 +228,9 @@ class DiffWidget(HorizontalScroll):
     # Minimum width to show side-by-side (each side needs ~60 chars)
     SIDE_BY_SIDE_MIN_WIDTH = 130
 
+    # Expand tabs at input so ``len(text)`` matches rendered cell width.
+    TAB_SIZE = 8
+
     def __init__(
         self,
         old: str,
@@ -229,8 +243,8 @@ class DiffWidget(HorizontalScroll):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self._old = old
-        self._new = new
+        self._old = old.expandtabs(self.TAB_SIZE)
+        self._new = new.expandtabs(self.TAB_SIZE)
         self._path = path
         self._context_lines = context_lines
         self._replace_all = replace_all

--- a/claudechic/widgets/reports/context.py
+++ b/claudechic/widgets/reports/context.py
@@ -6,6 +6,9 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
+# Suffix multipliers for token counts in /context output (e.g. "22.6k", "1m").
+_SUFFIX_MULT = {"": 1, "k": 1_000, "m": 1_000_000}
+
 
 def parse_context_markdown(content: str) -> dict:
     """Parse context markdown into structured data."""
@@ -21,23 +24,27 @@ def parse_context_markdown(content: str) -> dict:
     if model_match:
         data["model"] = model_match.group(1)
 
-    # Parse tokens line: **Tokens:** 18.4k / 200.0k (9%)
-    tokens_match = re.search(r"\*\*Tokens:\*\*\s*([\d.]+)k?\s*/\s*([\d.]+)k", content)
+    # Parse tokens line: **Tokens:** 18.4k / 200.0k (9%), 184.2k / 1000.0k, or 22.6k / 1m
+    tokens_match = re.search(
+        r"\*\*Tokens:\*\*\s*([\d.]+)([kmKM]?)\s*/\s*([\d.]+)([kmKM]?)", content
+    )
     if tokens_match:
-        used_str, total_str = tokens_match.groups()
-        data["tokens_used"] = int(float(used_str) * 1000)
-        data["tokens_total"] = int(float(total_str) * 1000)
+        used_str, used_suffix, total_str, total_suffix = tokens_match.groups()
+        data["tokens_used"] = int(float(used_str) * _SUFFIX_MULT[used_suffix.lower()])
+        data["tokens_total"] = int(
+            float(total_str) * _SUFFIX_MULT[total_suffix.lower()]
+        )
 
     # Parse category rows from markdown table
     # | System prompt | 2.9k | 1.5% |
     for match in re.finditer(
-        r"\|\s*([^|]+?)\s*\|\s*([\d.]+)(k?)\s*\|\s*([\d.]+)%\s*\|", content
+        r"\|\s*([^|]+?)\s*\|\s*([\d.]+)([kmKM]?)\s*\|\s*([\d.]+)%\s*\|", content
     ):
         name, tokens_raw, suffix, pct_str = match.groups()
         name = name.strip()
         if name in ("Category", "-------"):
             continue
-        tokens = int(float(tokens_raw) * (1000 if suffix == "k" else 1))
+        tokens = int(float(tokens_raw) * _SUFFIX_MULT[suffix.lower()])
         data["categories"].append(
             {
                 "name": name,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -33,9 +33,17 @@
   --md-footer-bg-color--dark: #000000;
 }
 
-/* Header - hidden */
-.md-header {
-  display: none;
+/* Header - hidden on wide screens, visible on mobile for hamburger nav */
+@media screen and (min-width: 76.25em) {
+  .md-header {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 76.1875em) {
+  .md-header {
+    background-color: #000000;
+  }
 }
 
 /* Responsive video container */

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -622,6 +622,128 @@ def test_word_diff_with_go_syntax():
         assert not text[0].isalnum() or start == 0 or not old_line[start - 1].isalnum()
 
 
+def test_highlight_text_preserves_tab_positions():
+    """Tab-indented source must keep token spans aligned with raw text.
+
+    Regression test: with ``tabsize=8`` (Pygments default for many lexers),
+    tabs get expanded to 8 spaces inside token text and the position
+    accumulator drifts +7 chars per tab — so Go syntax spans land on the
+    wrong characters or extend past end-of-content. Mitigated by passing
+    ``stripnl=False, ensurenl=False`` (which keeps the default ``tabsize=0``)
+    plus expanding tabs at the diff input.
+    """
+    from claudechic.widgets.content.diff import _highlight_text
+
+    src = 'func main() {\n\tprintln("hi")\n}'
+    content = _highlight_text(src, "go")
+
+    # Content length must equal source length
+    assert len(content.plain) == len(src)
+
+    # Every span must lie within bounds, and the slice must match the source
+    # (non-trivial: catches drift even when spans stay in-bounds).
+    for span in content._spans:
+        assert 0 <= span.start <= span.end <= len(src), (
+            f"span {span} out of bounds for len={len(src)}"
+        )
+
+    # Spot-check that the keyword `func` got highlighted at position 0
+    keyword_spans = [s for s in content._spans if s.start == 0 and s.end == 4]
+    assert keyword_spans, "expected a span covering `func` at [0:4]"
+
+
+def test_highlight_text_markdown_with_fenced_code():
+    """Fenced code-block spans must land inside the block, not at index 0.
+
+    Regression test: Pygments' markdown lexer delegates fenced code blocks
+    to a sub-lexer (e.g. python) whose ``get_tokens_unprocessed`` emits
+    indices reset to 0 — relative to the inner code, not the full document.
+    Trusting those indices splatted Python keyword colors onto the start of
+    the file (e.g. across a heading), making markdown diffs look broken.
+    """
+    from claudechic.widgets.content.diff import _highlight_text
+
+    # Content after the code block is required: the markdown lexer's
+    # fenced-block regex only matches with a newline after the closing ```,
+    # and ``_highlight_text`` strips lone trailing newlines via
+    # ``"\n".join(splitlines())``. Trailing content keeps that newline alive
+    # so the python sub-lexer fires (the path that triggered the bug).
+    src = "# Heading\n\n```python\ndef foo():\n    return 1\n```\n\nend\n"
+    content = _highlight_text(src, "markdown")
+    rendered = content.plain
+
+    # Every span must lie within bounds of the rendered content
+    for span in content._spans:
+        assert 0 <= span.start <= span.end <= len(rendered), (
+            f"span {span} out of bounds for len={len(rendered)}"
+        )
+
+    # The `def` keyword must be highlighted at its real source position,
+    # not at index 0 (which is where the bug placed it).
+    def_pos = rendered.index("def")
+    def_spans = [
+        s for s in content._spans if s.start == def_pos and s.end == def_pos + 3
+    ]
+    assert def_spans, f"expected a span covering `def` at [{def_pos}:{def_pos + 3}]"
+
+    # Negative assertion: no span should sit at [0:3] over the heading text.
+    # Mirrors the bug's exact failure mode (`def`-keyword color at file start).
+    assert not [s for s in content._spans if (s.start, s.end) == (0, 3)], (
+        "no syntax span should land on the first 3 chars of the heading"
+    )
+
+
+def test_highlight_text_rst_with_code_block():
+    """RST ``.. code-block::`` directives have the same delegation bug shape.
+
+    Pygments' RST lexer delegates ``.. code-block:: python`` content to the
+    python sub-lexer, which emits indices reset to 0 — same root cause as
+    the markdown fenced-block bug. Locks in that the position-accumulator
+    fix covers RST too, since it's the second confirmed instance of the
+    Pygments delegation anti-pattern in the wild.
+    """
+    from claudechic.widgets.content.diff import _highlight_text
+
+    src = (
+        "Heading\n=======\n\n"
+        ".. code-block:: python\n\n"
+        "    def foo():\n"
+        "        return 1\n\n"
+        "end\n"
+    )
+    content = _highlight_text(src, "rst")
+    rendered = content.plain
+
+    for span in content._spans:
+        assert 0 <= span.start <= span.end <= len(rendered), (
+            f"span {span} out of bounds for len={len(rendered)}"
+        )
+
+    def_pos = rendered.index("def")
+    def_spans = [
+        s for s in content._spans if s.start == def_pos and s.end == def_pos + 3
+    ]
+    assert def_spans, f"expected a span covering `def` at [{def_pos}:{def_pos + 3}]"
+
+
+def test_diff_widget_expands_tabs():
+    """Tabs in input must be expanded so ``len()`` matches rendered cell width.
+
+    Without expansion, tab-indented sources (Go, Makefiles) misalign because
+    terminals render ``\\t`` at up to 8 cols while ``len`` counts it as 1 —
+    backgrounds underfill and side-by-side columns drift.
+    """
+    from claudechic.widgets.content.diff import DiffWidget
+
+    old = "func main() {\n\treturn 1\n}"
+    new = "func main() {\n\treturn 2\n}"
+
+    w = DiffWidget(old=old, new=new, path="main.go")
+    assert "\t" not in w._old
+    assert "\t" not in w._new
+    assert " " * w.TAB_SIZE + "return 1" in w._old
+
+
 # --- Lazy collapsible tests ---
 
 


### PR DESCRIPTION
## Summary

Pulls 9 bug fixes from `mrocklin/claudechic@main` that were missing on our fork. Same squashed commit content already landed on `develop` as `52ae341`; this PR brings it to `main` (going via a fresh branch off `main` rather than a `develop` → `main` PR to avoid re-introducing `.project_team/` paths).

## What's included

| Upstream SHA | Fix |
|---|---|
| `0411d0c` | Show header on mobile for hamburger nav (fixes #62) |
| `620cfa9` | Pass `/ultrareview` through to the SDK |
| `15f4e81` | Warn when colors look washed out over SSH |
| `d46b3af` | Fix Go syntax highlighting drift in diff viewer |
| `e0cea68` | Expand tabs in DiffWidget input so widths match rendered cells |
| `796dbd4` | Catch generic exceptions in initial connect worker so SDK init timeouts surface as a clean message (path-sanitizer half of the upstream commit was obsoleted by our bijective `_path_to_hex` scheme) |
| `20c8cec` | Strip `\r` from PTY shell output so lines don't overwrite each other (fixes #66) |
| `5002c1c` | Parse "1m" suffix in `/context` output, with a manual merge that preserves our model-line parsing that upstream had removed |
| `e854057` | Fix syntax highlighting in diffs for markdown/RST fenced code blocks |

## Skipped from the upstream range

- `f3f41e9` (session lookup with underscores #52) — already fixed in our `encode_project_key()` refactor in `sessions.py`. Patch-id matches once normalized.

## Deferred to follow-up PRs (per reviewer)

- `6ff434b` Remove plan-swarm feature — standalone PR (touches 5+ files; deserves dedicated review).
- `0e220c9` Use SDK `get_context_usage()` for per-model context window — verify against our context-bar implementation first.
- `38478e4`, `82ccf66`, `a6624cf`, `c132c65`, `e893a8c` — each needs individual eval against sprustonlab equivalents.

## Verification

- `ruff check` + `ruff format`: clean.
- `pyright`: 0 errors / 0 warnings.
- `pytest --timeout=30`: **866 passed**, 1 skipped, 2 xfailed in 3:19.

## Branch policy note

No `.project_team/` paths touched, so the `no-project-team-additions-on-main` required check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)