### PR TITLE
chore: remove plan-swarm feature

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -1404,7 +1404,6 @@ Key Rules:
         "auto",
         "acceptEdits",
         "plan",
-        "planSwarm",
         "bypassPermissions",
     }
 

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -762,7 +762,6 @@ class ChatApp(App):
     def action_cycle_permission_mode(self) -> None:
         """Cycle global permission mode: bypassPermissions -> default -> acceptEdits -> plan.
 
-        planSwarm is not in the cycle - use /plan-swarm to enter, shift-tab to exit.
         Changes apply to ALL agents immediately.
         """
         if not self.agent_mgr:
@@ -771,12 +770,8 @@ class ChatApp(App):
         modes = ["bypassPermissions", "auto", "acceptEdits", "plan", "default"]
         current = self.agent_mgr.global_permission_mode
 
-        # If in planSwarm, exit to bypassPermissions (not in normal cycle)
-        if current not in modes:
-            next_mode = "bypassPermissions"
-        else:
-            next_idx = (modes.index(current) + 1) % len(modes)
-            next_mode = modes[next_idx]
+        next_idx = (modes.index(current) + 1) % len(modes)
+        next_mode = modes[next_idx]
 
         # Schedule the async call to update all agents
         agent_mgr = self.agent_mgr
@@ -2950,13 +2945,6 @@ class ChatApp(App):
             exit_on_error=False,
         )
 
-        # If in planSwarm mode, this is the task - spawn agents and send orchestrator prompt
-        if agent and agent.permission_mode == "planSwarm":
-            from claudechic.commands import start_plan_swarm
-
-            start_plan_swarm(self, prompt)
-            return
-
         # User message will be mounted by _on_agent_prompt_sent callback
         self._send_to_active_agent(prompt)
 
@@ -4367,7 +4355,7 @@ class ChatApp(App):
         if result and result != agent.model:
             self._set_agent_model(result)
 
-    # exclusive=False allows parallel agent creation (needed for plan-swarm).
+    # exclusive=False allows parallel agent creation.
     # Race on switch_to is acceptable - last created wins for active agent.
     @work(group="new_agent", exclusive=False, exit_on_error=False)
     async def _create_new_agent(

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import os
 import subprocess
 import time
-import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -114,7 +113,6 @@ COMMANDS: list[tuple[str, str, list[str]]] = [
     ),
     ("/welcome", "Show welcome message", []),
     ("/reviewer", "Spawn a review agent for current changes", []),
-    ("/plan-swarm", "Start swarm planning with multiple approaches", []),
     ("/rewind", "Rewind to a previous checkpoint", []),
     ("/workflow", "Manage workflows", ["/workflow list", "/workflow reload"]),
     ("/help", "Show help", []),
@@ -156,8 +154,6 @@ def get_help_commands() -> list[tuple[str, str]]:
             display_name = "/reviews [job_id]"
         elif name == "/reviewer":
             display_name = "/reviewer [focus]"
-        elif name == "/plan-swarm":
-            display_name = "/plan-swarm"
         elif name == "/rewind":
             display_name = "/rewind [index]"
         result.append((display_name, desc))
@@ -316,10 +312,6 @@ def handle_command(app: ChatApp, prompt: str) -> bool:
         _track_command(app, "reviewer")
         context = cmd.split(maxsplit=1)[1] if cmd.startswith("/reviewer ") else None
         return _handle_review(app, context)
-
-    if cmd == "/plan-swarm":
-        _track_command(app, "plan-swarm")
-        return _handle_plan_swarm(app)
 
     if cmd == "/help":
         _track_command(app, "help")
@@ -1027,175 +1019,3 @@ def _handle_analytics(app: ChatApp, command: str) -> bool:
     status = "enabled" if enabled else "disabled"
     app.notify(f"Analytics {status}, ID: {user_id[:8]}...")
     return True
-
-
-# =============================================================================
-# Plan Swarm - Multi-perspective planning with debate
-# =============================================================================
-
-SWARM_PERSPECTIVE_PROMPT = """\
-You are the {perspective_upper} planner in a swarm planning session.
-
-YOUR IDENTITY: {swarm_id}-{perspective}
-YOUR PEERS:
-{peers}
-ORCHESTRATOR: {orchestrator}
-
-TASK: {task}
-
-YOUR PERSPECTIVE: {perspective_description}
-
-== RULES ==
-
-- Research and design only - do NOT write or edit code
-- Use Task tool with Explore subagents to understand the codebase
-- Read files with Read, Glob, Grep
-- Form strong opinions based on evidence
-
-== PROTOCOL ==
-
-1. RESEARCH: Launch 2-3 Explore subagents in parallel to understand the codebase.
-
-2. PROPOSE: Send your plan to peers and orchestrator:
-   message_agent("{peer1}", "PROPOSAL from {perspective}: [detailed plan with rationale]")
-   message_agent("{peer2}", "PROPOSAL from {perspective}: [detailed plan with rationale]")
-   message_agent("{orchestrator}", "PROPOSAL SENT: [1-sentence summary]")
-
-3. DEBATE: When you receive peer proposals, respond directly:
-   - Challenge assumptions with evidence from the codebase
-   - Defend your approach, but acknowledge good points
-   - You CAN change your mind if convinced
-
-4. CONCLUDE: After 2-3 rounds, send final position:
-   message_agent("{orchestrator}", "FINAL POSITION: [refined plan, noting changes from debate]")
-
-== DEBATE STYLE ==
-
-Be direct. Use evidence: "The pattern in auth.py uses X, so..." or "I found 3 places that would break..."
-"""
-
-PERSPECTIVE_DESCRIPTIONS = {
-    "conservative": (
-        "Minimize risk. Prefer proven patterns. Prioritize reliability.\n"
-        "- Use established solutions over novel approaches\n"
-        "- Minimize changes to existing architecture\n"
-        "- Ensure backwards compatibility\n"
-        "- Focus on maintainability and testability\n"
-        "- When in doubt, do less"
-    ),
-    "balanced": (
-        "Balance pragmatism with improvement. Follow best practices.\n"
-        "- Consider trade-offs between innovation and stability\n"
-        "- Apply industry-standard patterns where appropriate\n"
-        "- Weigh implementation cost against long-term benefits\n"
-        "- Find the 'Goldilocks' solution - not too much, not too little\n"
-        "- Be the voice of reason between extremes"
-    ),
-    "creative": (
-        "Challenge assumptions. Propose novel approaches. Take calculated risks.\n"
-        "- Question whether the existing approach is optimal\n"
-        "- Consider unconventional solutions that could be game-changers\n"
-        "- Identify opportunities others might miss\n"
-        "- Accept higher risk for potentially higher reward\n"
-        "- Push the boundaries of what's possible"
-    ),
-}
-
-SWARM_ORCHESTRATOR_PROMPT = """\
-You are orchestrating a swarm planning debate for task: {task}
-
-== FIRST: CALL EnterPlanMode ==
-
-== AGENTS (already spawned) ==
-
-- {swarm_id}-conservative (risk-averse, proven patterns)
-- {swarm_id}-balanced (pragmatic middle ground)
-- {swarm_id}-creative (novel approaches, higher risk/reward)
-
-They will research, propose plans to each other, debate, and send you final positions.
-
-== YOUR JOB ==
-
-1. Call EnterPlanMode now
-
-2. Monitor: You'll receive PROPOSAL SENT and FINAL POSITION messages
-
-3. If stuck: message_agent("{swarm_id}-conservative", "What's your status?")
-
-4. Synthesize: Once you have final positions, write synthesis to your plan file
-
-5. User choice via AskUserQuestion: Conservative / Balanced / Creative / Hybrid
-
-6. Finalize: Write final plan, call ExitPlanMode, then close_agent on all 3
-"""
-
-
-def _build_perspective_prompt(
-    perspective: str, swarm_id: str, task: str, peers: list[str], orchestrator: str
-) -> str:
-    """Build the prompt for a perspective agent."""
-    peer1, peer2 = peers
-    peers_list = "\n".join(f"- {p}" for p in peers)
-
-    return SWARM_PERSPECTIVE_PROMPT.format(
-        perspective=perspective,
-        perspective_upper=perspective.upper(),
-        perspective_description=PERSPECTIVE_DESCRIPTIONS[perspective],
-        swarm_id=swarm_id,
-        task=task,
-        peers=peers_list,
-        peer1=peer1,
-        peer2=peer2,
-        orchestrator=orchestrator,
-    )
-
-
-def _handle_plan_swarm(app: ChatApp) -> bool:
-    """Enter plan-swarm mode. Next user message will spawn perspective agents."""
-    agent = app._agent
-    if not agent:
-        app.notify("No active agent", severity="error")
-        return True
-
-    async def enter_mode():
-        await agent.set_permission_mode("planSwarm")
-
-    app.run_worker(enter_mode(), exclusive=False)
-    app.notify("Plan swarm mode - enter your task")
-    return True
-
-
-def start_plan_swarm(app: ChatApp, task: str) -> None:
-    """Spawn perspective agents and send orchestrator prompt. Called when user sends first message in planSwarm mode."""
-    agent = app._agent
-    if not agent:
-        return
-
-    # Reset mode to auto (the orchestrator will enter plan mode via EnterPlanMode)
-    async def reset_mode():
-        await agent.set_permission_mode("auto")
-
-    app.run_worker(reset_mode(), exclusive=False)
-
-    cwd = agent.cwd
-    orchestrator = agent.name
-
-    # Generate unique swarm ID
-    swarm_id = str(uuid.uuid4())[:8]
-
-    # Spawn the 3 perspective agents
-    perspectives = ["conservative", "balanced", "creative"]
-    for p in perspectives:
-        peers = [f"{swarm_id}-{x}" for x in perspectives if x != p]
-        prompt = _build_perspective_prompt(p, swarm_id, task, peers, orchestrator)
-        agent_name = f"{swarm_id}-{p}"
-        app._create_new_agent(
-            agent_name, cwd, switch_to=False, initial_prompt=(prompt, "/plan-swarm")
-        )
-
-    # Send orchestrator prompt to current agent
-    orchestrator_prompt = SWARM_ORCHESTRATOR_PROMPT.format(
-        task=task,
-        swarm_id=swarm_id,
-    )
-    app._send_to_active_agent(orchestrator_prompt, display_as="/plan-swarm")

--- a/claudechic/defaults/global/hints.yaml
+++ b/claudechic/defaults/global/hints.yaml
@@ -28,10 +28,6 @@
   message: "Tip: Use /reviewer to have your current agent review and critique your changes before committing. Add a focus area like /reviewer security."
   lifecycle: show-once
 
-- id: tip_plan_swarm
-  message: "Tip: Use /plan-swarm then describe your task. Three perspective agents (conservative, balanced, creative) will research, debate, and propose plans for you to choose from."
-  lifecycle: show-once
-
 - id: tip_rewind
   message: "Tip: Use /rewind to undo file changes — Claude auto-checkpoints files as you work. Pick a snapshot to roll back to."
   lifecycle: show-once

--- a/claudechic/styles.tcss
+++ b/claudechic/styles.tcss
@@ -110,10 +110,6 @@ DiagnosticsLabel:hover {
     color: $secondary;
 }
 
-.footer-label.plan-swarm-mode {
-    color: $error;
-}
-
 /* Shared block styling - all content blocks */
 ChatMessage, BaseToolWidget, ThinkingIndicator, ErrorMessage, SystemInfo, #input-container {
     background: transparent;

--- a/claudechic/widgets/layout/footer.py
+++ b/claudechic/widgets/layout/footer.py
@@ -446,36 +446,26 @@ class StatusFooter(Static):
         if label := self.query_one_optional(
             "#permission-mode-label", PermissionModeLabel
         ):
-            if value == "planSwarm":
-                label.update("Plan swarm")
-                label.set_class(False, "active")
-                label.set_class(False, "plan-mode")
-                label.set_class(True, "plan-swarm-mode")
-            elif value == "plan":
+            if value == "plan":
                 label.update("Plan mode")
                 label.set_class(False, "active")
                 label.set_class(True, "plan-mode")
-                label.set_class(False, "plan-swarm-mode")
             elif value == "auto":
                 label.update("Auto: safe tools auto-approved")
                 label.set_class(True, "active")
                 label.set_class(False, "plan-mode")
-                label.set_class(False, "plan-swarm-mode")
             elif value == "acceptEdits":
                 label.update("Auto-edit: on")
                 label.set_class(True, "active")
                 label.set_class(False, "plan-mode")
-                label.set_class(False, "plan-swarm-mode")
             elif value == "bypassPermissions":
                 label.update("Bypass: all auto-approved")
                 label.set_class(True, "active")
                 label.set_class(False, "plan-mode")
-                label.set_class(False, "plan-swarm-mode")
             else:  # default
                 label.update("Auto-edit: off")
                 label.set_class(False, "active")
                 label.set_class(False, "plan-mode")
-                label.set_class(False, "plan-swarm-mode")
 
     def update_processes(self, processes: list[BackgroundProcess]) -> None:
         """Update the process indicator."""

--- a/tests/test_agent_permission.py
+++ b/tests/test_agent_permission.py
@@ -62,7 +62,6 @@ class TestPermissionModes:
             "auto",
             "acceptEdits",
             "plan",
-            "planSwarm",
             "bypassPermissions",
         }
         assert expected == Agent.PERMISSION_MODES


### PR DESCRIPTION
## Summary
- Removes the `/plan-swarm` command, `planSwarm` permission mode, and all supporting code (~170 lines of swarm orchestrator/perspective prompts in `commands.py`, plus footer/CSS branches and the `tip_plan_swarm` hint).
- Simplifies the permission-mode cycle now that there's no out-of-cycle mode to escape from.
- Net diff: 7 files, +4 / -216.

## Background
Per the deferred-commit roadmap, this is PR #1 of 4 derived from upstream mrocklin/claudechic syncs. Mirrors upstream commit `6ff434b` but executed as a fresh deletion (rather than a cherry-pick) to avoid sprustonlab-specific conflicts. Subsequent PRs will land ToolSearch compact rendering, post-turn wakeup messages, and SDK `get_context_usage()`.

## Files touched
- `claudechic/commands.py` — uuid import, registry entry, autocomplete elif, dispatch block, ~170-line plan-swarm section
- `claudechic/agent.py` — drop `"planSwarm"` from `PERMISSION_MODES`
- `claudechic/app.py` — remove planSwarm dispatch in send handler; simplify cycle; scrub stale comment
- `claudechic/widgets/layout/footer.py` — remove planSwarm branch + `plan-swarm-mode` class toggles
- `claudechic/styles.tcss` — remove `.footer-label.plan-swarm-mode` rule
- `claudechic/defaults/global/hints.yaml` — remove `tip_plan_swarm`
- `tests/test_agent_permission.py` — drop `planSwarm` from expected set

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format` — clean
- [x] `pyright claudechic/agent.py claudechic/app.py claudechic/commands.py claudechic/widgets/layout/footer.py` — 0 errors
- [x] `pytest tests/test_agent_permission.py` — 19 passed
- [x] `pytest tests/ -n auto --timeout=30` — 864 passed, 1 skipped, 2 xfailed; 2 unrelated flakes in `test_app_ui.py` (pass on isolated rerun)
- [ ] Manual smoke (reviewer): launch `claudechic`, type `/`, confirm `/plan-swarm` is absent from autocomplete; cycle Shift+Tab through `default → auto → acceptEdits → plan → bypassPermissions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)