### PR TITLE
perf(diff): parallelize git subprocesses + restore untracked cap (closes #45)

### DIFF
--- a/claudechic/features/diff/git.py
+++ b/claudechic/features/diff/git.py
@@ -2,9 +2,12 @@
 
 import asyncio
 import difflib
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -87,25 +90,54 @@ class FileStat:
 # Skip reading contents of untracked files larger than this
 MAX_UNTRACKED_FILE_SIZE = 1024
 
+# If a working tree has more than this many untracked files, skip the
+# untracked-file enumeration entirely. Reading content + stat-ing thousands
+# of files (common in repos with weak .gitignore -- node_modules, build/,
+# data/, etc.) blocks the diff screen for tens of seconds. The earlier cap
+# of 4 was too aggressive for the W6 fixture case (a feature branch with a
+# few new files); 40 is a comfortable upper bound for "interactive review"
+# while still keeping pathological repos responsive. When the cap fires,
+# the rest of the diff (tracked changes) still renders normally.
+MAX_UNTRACKED_FILES = 40
 
-async def get_file_stats(cwd: str, target: str = "HEAD") -> list[FileStat]:
-    """Get file stats (additions/deletions) for tracked changes and untracked files."""
-    stats = []
-    seen_paths: set[str] = set()
 
-    # Get tracked file changes via git diff
+async def _run_git(cwd: str, *args: str) -> tuple[int, str]:
+    """Run a git subprocess and return (returncode, stdout-decoded).
+
+    Centralizes the create_subprocess_exec + communicate dance so callers
+    can launch multiple git invocations concurrently via ``asyncio.gather``.
+    On Windows ``create_subprocess_exec`` adds ~100-300 ms of process-startup
+    latency per call; gathering removes the cumulative tax.
+    """
     proc = await asyncio.create_subprocess_exec(
         "git",
-        "diff",
-        target,
-        "--numstat",
+        *args,
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
     stdout, _ = await proc.communicate()
-    if proc.returncode == 0:
-        for line in stdout.decode().strip().split("\n"):
+    rc = proc.returncode if proc.returncode is not None else -1
+    return rc, stdout.decode()
+
+
+async def get_file_stats(cwd: str, target: str = "HEAD") -> list[FileStat]:
+    """Get file stats (additions/deletions) for tracked changes and untracked files.
+
+    The two git subprocesses (``diff --numstat`` and ``ls-files --others``)
+    are independent and run concurrently to avoid sequential process-startup
+    latency on Windows.
+    """
+    stats: list[FileStat] = []
+    seen_paths: set[str] = set()
+
+    (numstat_rc, numstat_out), (untracked_rc, untracked_out) = await asyncio.gather(
+        _run_git(cwd, "diff", target, "--numstat"),
+        _run_git(cwd, "ls-files", "--others", "--exclude-standard"),
+    )
+
+    if numstat_rc == 0:
+        for line in numstat_out.strip().split("\n"):
             if not line:
                 continue
             parts = line.split("\t")
@@ -119,127 +151,128 @@ async def get_file_stats(cwd: str, target: str = "HEAD") -> list[FileStat]:
             stats.append(FileStat(path=path, additions=adds, deletions=dels))
             seen_paths.add(path)
 
-    # Get untracked files
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "ls-files",
-        "--others",
-        "--exclude-standard",
-        cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await proc.communicate()
-    if proc.returncode == 0:
+    if untracked_rc == 0:
         untracked = [
             line
-            for line in stdout.decode().strip().split("\n")
+            for line in untracked_out.strip().split("\n")
             if line and line not in seen_paths
         ]
-        for line in untracked:
-            file_path = Path(cwd, line)
-            line_count = 0
-            try:
-                # Only read small files
-                if file_path.stat().st_size <= MAX_UNTRACKED_FILE_SIZE:
-                    line_count = len(file_path.read_text(encoding="utf-8").splitlines())
-            except (OSError, UnicodeDecodeError):
-                pass
-            stats.append(
-                FileStat(path=line, additions=line_count, deletions=0, untracked=True)
+        if len(untracked) > MAX_UNTRACKED_FILES:
+            log.warning(
+                "Skipping untracked-file enumeration in %s: %d untracked files exceeds cap of %d.",
+                cwd,
+                len(untracked),
+                MAX_UNTRACKED_FILES,
             )
+        else:
+            for line in untracked:
+                file_path = Path(cwd, line)
+                line_count = 0
+                try:
+                    # Only read small files
+                    if file_path.stat().st_size <= MAX_UNTRACKED_FILE_SIZE:
+                        line_count = len(
+                            file_path.read_text(encoding="utf-8").splitlines()
+                        )
+                except (OSError, UnicodeDecodeError):
+                    pass
+                stats.append(
+                    FileStat(
+                        path=line, additions=line_count, deletions=0, untracked=True
+                    )
+                )
 
     return stats
 
 
 async def get_changes(cwd: str, target: str = "HEAD") -> list[FileChange]:
-    """Get all changes vs target (default HEAD) via git diff."""
-    # Get list of changed files with status
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "diff",
-        target,
-        "--name-status",
-        cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    """Get all changes vs target (default HEAD) via git diff.
+
+    Runs the three git subprocesses concurrently:
+
+      1. ``git diff <target> --name-status`` -- tracked-change list
+      2. ``git diff <target> --no-ext-diff``  -- full unified diff (hunks)
+      3. ``git ls-files --others --exclude-standard`` -- untracked files
+
+    None of the calls reads the others' output, so ``asyncio.gather`` runs
+    them in parallel. On Windows, sequential ``create_subprocess_exec``
+    adds ~100-300 ms per call; gathering removes the cumulative tax.
+
+    The middle call is *speculative*: its output is only used when
+    ``--name-status`` is non-empty. We pay for one always-run ``git diff``
+    even when there are no tracked changes; that is far cheaper than
+    serializing three subprocess startups in the common case.
+    """
+    (
+        (name_status_rc, name_status_out),
+        (full_diff_rc, full_diff_out),
+        (untracked_rc, untracked_out),
+    ) = await asyncio.gather(
+        _run_git(cwd, "diff", target, "--name-status"),
+        _run_git(cwd, "diff", target, "--no-ext-diff"),
+        _run_git(cwd, "ls-files", "--others", "--exclude-standard"),
     )
-    stdout, _ = await proc.communicate()
-    if proc.returncode != 0:
+
+    if name_status_rc != 0:
         return []
 
-    files = _parse_name_status(stdout.decode())
+    files = _parse_name_status(name_status_out)
     # NOTE: do NOT early-return when ``files`` is empty. ``--name-status``
     # only reports tracked changes vs ``target``; untracked files (which
-    # are scanned below via ``git ls-files --others``) must still
-    # participate. Empty tracked diff with non-empty untracked set is
-    # the W6 fixture case (feature branch matches ``origin/main`` but
-    # working tree has new files). This complements the s8a count-cap
-    # removal (commit 4dfe650) -- both bugs gated untracked rendering
-    # on the tracked diff; this is the second gate.
-    if files:
-        # Get full diff content for parsing only when we have tracked
-        # changes to merge it into. Use ``--no-ext-diff`` to ensure
-        # unified diff format (not difft, delta, etc.).
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "diff",
-            target,
-            "--no-ext-diff",
-            cwd=cwd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        if proc.returncode == 0:
-            files = _merge_diff_content(files, stdout.decode())
-        # If the second git diff failed, ``files`` already has the
-        # tracked entries from --name-status (without hunks); fall
-        # through to the untracked scan below.
+    # are scanned below) must still participate. Empty tracked diff with
+    # non-empty untracked set is the W6 fixture case (feature branch
+    # matches ``origin/main`` but working tree has new files). This
+    # complements the s8a count-cap removal (commit 4dfe650) -- both
+    # bugs gated untracked rendering on the tracked diff; this is the
+    # second gate.
+    if files and full_diff_rc == 0:
+        # Merge hunk content from the speculative full-diff call. If the
+        # full diff failed, ``files`` keeps the tracked entries from
+        # --name-status (without hunks); fall through to untracked scan.
+        files = _merge_diff_content(files, full_diff_out)
 
     # Add untracked files as synthetic diffs
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "ls-files",
-        "--others",
-        "--exclude-standard",
-        cwd=cwd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await proc.communicate()
-
-    if proc.returncode == 0:
+    if untracked_rc == 0:
         tracked_paths = {f.path for f in files}
         untracked = [
             line
-            for line in stdout.decode().strip().split("\n")
+            for line in untracked_out.strip().split("\n")
             if line and line not in tracked_paths
         ]
-        for line in untracked:
-            file_path = Path(cwd, line)
-            try:
-                # Only read small files for synthetic diff
-                if file_path.stat().st_size <= MAX_UNTRACKED_FILE_SIZE:
-                    content = file_path.read_text(encoding="utf-8")
-                    lines = content.splitlines()
-                    hunk = Hunk(
-                        old_start=0,
-                        old_count=0,
-                        new_start=1,
-                        new_count=len(lines),
-                        old_lines=[],
-                        new_lines=lines,
-                    )
-                    files.append(
-                        FileChange(path=line, status="untracked", hunks=[hunk])
-                    )
-                else:
-                    # Large file - include but without diff content
+        if len(untracked) > MAX_UNTRACKED_FILES:
+            log.warning(
+                "Skipping untracked-file enumeration in %s: %d untracked files exceeds cap of %d.",
+                cwd,
+                len(untracked),
+                MAX_UNTRACKED_FILES,
+            )
+        else:
+            for line in untracked:
+                file_path = Path(cwd, line)
+                try:
+                    # Only read small files for synthetic diff
+                    if file_path.stat().st_size <= MAX_UNTRACKED_FILE_SIZE:
+                        content = file_path.read_text(encoding="utf-8")
+                        lines = content.splitlines()
+                        hunk = Hunk(
+                            old_start=0,
+                            old_count=0,
+                            new_start=1,
+                            new_count=len(lines),
+                            old_lines=[],
+                            new_lines=lines,
+                        )
+                        files.append(
+                            FileChange(path=line, status="untracked", hunks=[hunk])
+                        )
+                    else:
+                        # Large file - include but without diff content
+                        files.append(
+                            FileChange(path=line, status="untracked", hunks=[])
+                        )
+                except (OSError, UnicodeDecodeError):
+                    # Binary or unreadable - include but without diff content
                     files.append(FileChange(path=line, status="untracked", hunks=[]))
-            except (OSError, UnicodeDecodeError):
-                # Binary or unreadable - include but without diff content
-                files.append(FileChange(path=line, status="untracked", hunks=[]))
 
     return files
 

--- a/claudechic/screens/diff.py
+++ b/claudechic/screens/diff.py
@@ -112,8 +112,28 @@ class DiffScreen(Screen[list[HunkComment]]):
         yield Static("Loading...", id="diff-empty")
         yield Footer()
 
-    async def on_mount(self) -> None:
-        """Fetch changes and build the diff view."""
+    def on_mount(self) -> None:
+        """Schedule the change-fetch off the mount path.
+
+        Returning synchronously lets Textual paint the ``Loading...``
+        placeholder from ``compose()`` before the (potentially slow on
+        Windows) git subprocesses run. The actual data load + UI
+        construction happens in ``_load_changes`` via ``run_worker``.
+        """
+        self.run_worker(
+            self._load_changes(),
+            group="diff-load",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _load_changes(self) -> None:
+        """Worker: fetch changes and build the diff view.
+
+        Lifted out of ``on_mount`` so the ``Loading...`` placeholder
+        from ``compose()`` actually renders during the git subprocess
+        round-trip. Issue #45.
+        """
         self._changes = await get_changes(str(self._cwd), self._target)
 
         # Remove placeholder.

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,10 +1,17 @@
 """Tests for git diff feature."""
 
+import subprocess
+
+import pytest
+
 from claudechic.features.diff.git import (
+    MAX_UNTRACKED_FILES,
     FileChange,
     _merge_diff_content,
     _parse_hunks,
     _parse_name_status,
+    get_changes,
+    get_file_stats,
 )
 
 
@@ -112,3 +119,79 @@ index abc..def 100644
         assert len(result) == 1
         assert len(result[0].hunks) == 1
         assert "new" in result[0].hunks[0].new_lines
+
+
+def _init_repo(path) -> None:
+    """Create a minimal git repo with one tracked commit so HEAD exists."""
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    seed = path / "seed.txt"
+    seed.write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=path, check=True)
+
+
+class TestUntrackedCap:
+    """MAX_UNTRACKED_FILES guards against pathological repos (1000s of
+    untracked files in node_modules / build / data dirs) hanging the diff
+    screen for tens of seconds.
+
+    Skip-all-if-many semantics: when the cap fires, the untracked listing
+    is dropped entirely; tracked changes are unaffected.
+    """
+
+    @pytest.mark.asyncio
+    async def test_under_cap_includes_all_untracked(self, tmp_path):
+        _init_repo(tmp_path)
+        n = MAX_UNTRACKED_FILES  # exactly at the cap -> still included
+        for i in range(n):
+            (tmp_path / f"u{i}.txt").write_text(f"hello {i}\n", encoding="utf-8")
+
+        changes = await get_changes(str(tmp_path))
+        untracked_paths = {c.path for c in changes if c.status == "untracked"}
+        assert len(untracked_paths) == n
+
+        stats = await get_file_stats(str(tmp_path))
+        untracked_stat_paths = {s.path for s in stats if s.untracked}
+        assert len(untracked_stat_paths) == n
+
+    @pytest.mark.asyncio
+    async def test_over_cap_skips_all_untracked(self, tmp_path, caplog):
+        _init_repo(tmp_path)
+        n = MAX_UNTRACKED_FILES + 1
+        for i in range(n):
+            (tmp_path / f"u{i}.txt").write_text(f"hi {i}\n", encoding="utf-8")
+
+        # Subscribe at WARNING so the cap-skip notice is captured. Attach
+        # to the package logger directly because `claudechic` may have
+        # propagate=False after setup_logging() runs in another test.
+        import logging
+
+        capture_logger = logging.getLogger("claudechic.features.diff.git")
+        with caplog.at_level(logging.WARNING, logger=capture_logger.name):
+            changes = await get_changes(str(tmp_path))
+            stats = await get_file_stats(str(tmp_path))
+
+        # No untracked entries should appear in either result.
+        assert not [c for c in changes if c.status == "untracked"]
+        assert not [s for s in stats if s.untracked]
+
+        # Cap-fire should be logged so users have a breadcrumb.
+        cap_msgs = [r for r in caplog.records if "exceeds cap" in r.getMessage()]
+        assert cap_msgs, "Expected a WARNING log when untracked cap fires"
+
+    @pytest.mark.asyncio
+    async def test_over_cap_keeps_tracked_changes(self, tmp_path):
+        """The cap on untracked files must not affect tracked-change rendering."""
+        _init_repo(tmp_path)
+        # One tracked modification.
+        (tmp_path / "seed.txt").write_text("seed\nmod\n", encoding="utf-8")
+        # And many untracked files.
+        for i in range(MAX_UNTRACKED_FILES + 5):
+            (tmp_path / f"u{i}.txt").write_text("x\n", encoding="utf-8")
+
+        changes = await get_changes(str(tmp_path))
+        tracked = [c for c in changes if c.status != "untracked"]
+        assert len(tracked) == 1
+        assert tracked[0].path == "seed.txt"


### PR DESCRIPTION
Closes #45.

## Summary
DiffScreen took seconds to appear on Windows even with a handful of changed files. Two compounding causes (both diagnosed in the issue), plus a related guardrail you asked for:

1. **Parallel git subprocesses** — `get_changes()` and `get_file_stats()` ran their independent git calls back-to-back. On Windows each `asyncio.create_subprocess_exec` carries 100-300 ms of process-startup tax, so the user paid the cumulative cost before any data arrived. Both now `asyncio.gather` their calls through a small `_run_git(cwd, *args)` helper. The middle call in `get_changes` is speculative (its hunks are only used when --name-status is non-empty); paying for one always-run \`git diff\` when there are no tracked changes is much cheaper than serializing three subprocess startups in the common case.

2. **DiffScreen mount no longer blocks the renderer** — \`on_mount\` was async and \`await get_changes(...)\` BEFORE removing the \`Loading...\` placeholder. Textual won't paint a frame between mount and the first await yield, so the placeholder never had a chance to appear; the screen looked frozen. \`on_mount\` is now sync and schedules the data fetch in a new \`_load_changes\` worker via \`run_worker\`. The placeholder paints immediately and is swapped out when the worker resolves.

3. **\`MAX_UNTRACKED_FILES = 40\`** — restored the cap that was removed in commit 4dfe650 (the original 4 was too aggressive for the W6 fixture). 40 leaves comfortable headroom for legitimate interactive review while keeping pathological repos (1000s of untracked files in node_modules / build / data) responsive. When the cap fires, the untracked listing is dropped entirely and a WARNING is logged so users have a breadcrumb; tracked changes are unaffected.

## Files
- \`claudechic/features/diff/git.py\` — \`_run_git\` helper; \`asyncio.gather\` in both \`get_changes\` and \`get_file_stats\`; \`MAX_UNTRACKED_FILES = 40\` constant + skip-with-log when exceeded.
- \`claudechic/screens/diff.py\` — \`on_mount\` becomes sync + spawns \`_load_changes\` worker.
- \`tests/test_diff.py\` — new \`TestUntrackedCap\` class with 3 cases: at-cap inclusion, over-cap skip + log assertion, tracked-changes-survive-cap.

## Test plan
- [x] \`ruff check\` / \`ruff format\` clean
- [x] \`pyright\` on touched files — 0 errors
- [x] \`pytest tests/test_diff.py tests/test_diff_workflows.py tests/test_diff_preview.py tests/test_workflow_restore.py\` — **47 passed** (3 new + 44 existing)
- [x] \`pytest tests/ -n auto --timeout=30\` — 866 passed (the 1-3 flakes observed under heavy parallel load all pass on isolated rerun; same pattern as #44)
- [ ] Manual: open \`/diff\` in a Windows repo and confirm the \`Loading...\` placeholder paints immediately, then is replaced by the diff

## Note for reviewer
While preparing this PR I noticed an uncommitted, unrelated set of changes in \`claudechic/widgets/layout/sidebar.py\` (a sidebar-mount cap on \`FilesSection\` with \`MAX_FILES = 50\` + overflow row). I left them out of this PR since you asked specifically for \`MAX_UNTRACKED_FILES\` in the git layer. They look reasonable and complementary; happy to fold them in or open a separate PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)