### PR TITLE
feat/fix: ToolSearch compact rendering + threading excepthook fix (mirror of #44)

### DIFF
--- a/claudechic/__main__.py
+++ b/claudechic/__main__.py
@@ -8,39 +8,19 @@ import threading
 from importlib.metadata import version
 
 from claudechic.app import ChatApp
-from claudechic.errors import setup_logging
+from claudechic.errors import excepthook, setup_logging, threading_excepthook
 
 # Set up file logging to ~/claudechic.log
 setup_logging()
 
 logger = logging.getLogger("claudechic")
 
-
-# --- Global exception hooks: capture ANY unhandled exception to the log ---
-
-
-def _excepthook(exc_type, exc_value, exc_tb):
-    """Log unhandled exceptions (except KeyboardInterrupt) before the interpreter dies."""
-    if exc_type is KeyboardInterrupt:
-        sys.__excepthook__(exc_type, exc_value, exc_tb)
-        return
-    logger.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
-    sys.__excepthook__(exc_type, exc_value, exc_tb)
-
-
-def _threading_excepthook(args):
-    """Log unhandled exceptions in threads."""
-    if args.exc_type is KeyboardInterrupt:
-        return
-    logger.critical(
-        "Unhandled thread exception in %s",
-        args.thread,
-        exc_info=(args.exc_type, args.exc_value, args.exc_tb),
-    )
-
-
-sys.excepthook = _excepthook
-threading.excepthook = _threading_excepthook
+# Install global exception hooks: capture ANY unhandled exception to the log.
+# (Definitions live in claudechic.errors so test modules can import the hooks
+# without also triggering this file's module-level setup_logging() side effect,
+# which would set propagate=False on the claudechic logger and break caplog.)
+sys.excepthook = excepthook
+threading.excepthook = threading_excepthook
 
 
 def main():

--- a/claudechic/enums.py
+++ b/claudechic/enums.py
@@ -44,6 +44,9 @@ class ToolName(StrEnum):
     # Skills
     SKILL = "Skill"
 
+    # Tool discovery
+    TOOL_SEARCH = "ToolSearch"
+
 
 class AgentStatus(StrEnum):
     """Agent status values (for sidebar UI display)."""

--- a/claudechic/errors.py
+++ b/claudechic/errors.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 import traceback
 from collections.abc import Callable
 from pathlib import Path
+from types import TracebackType
 from typing import Literal
 
 from claudechic.config import CONFIG
@@ -125,3 +127,44 @@ def log_exception(e: Exception, context: str = "") -> str:
     else:
         log.error(f"{e}\n{tb}")
         return str(e)
+
+
+# --- Global exception hooks ---
+#
+# Defined here (NOT in __main__.py) so test modules can import them without
+# also triggering __main__.py's module-level setup_logging() side effect,
+# which sets propagate=False on the claudechic logger and breaks pytest's
+# caplog fixture for any subsequent test in the same worker process.
+
+
+def excepthook(
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_tb: TracebackType | None,
+) -> None:
+    """Log unhandled exceptions (except KeyboardInterrupt) before the interpreter dies."""
+    if exc_type is KeyboardInterrupt:
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
+        return
+    log.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
+    sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+
+def threading_excepthook(args: threading.ExceptHookArgs) -> None:
+    """Log unhandled exceptions in threads.
+
+    The runtime field is ``exc_traceback`` (NOT ``exc_tb``); using the wrong
+    name raises AttributeError inside the hook, which the runtime swallows,
+    losing the original thread exception entirely.
+    """
+    if args.exc_type is KeyboardInterrupt:
+        return
+    # exc_value is typed as Optional, but is always set when exc_type is not None.
+    # Construct a fallback instance for the type checker; the runtime always
+    # provides a real exception alongside the type.
+    exc_value = args.exc_value if args.exc_value is not None else args.exc_type()
+    log.critical(
+        "Unhandled thread exception in %s",
+        args.thread,
+        exc_info=(args.exc_type, exc_value, args.exc_traceback),
+    )

--- a/claudechic/formatting.py
+++ b/claudechic/formatting.py
@@ -58,6 +58,39 @@ _AGENT_MESSAGE_RE = re.compile(r"^\[Message from agent '([^']+)'\]\n\n")
 _AGENT_SPAWNED_RE = re.compile(r"^\[Spawned by agent '([^']+)'\]\n\n")
 
 
+def strip_mcp_prefix(name: str) -> str:
+    """Strip 'mcp__<server>__' prefix for compact display."""
+    return re.sub(r"^mcp__[^_]+__", "", name)
+
+
+def extract_tool_search_names(content) -> list[str] | None:
+    """Extract tool names from a ToolSearch result.
+
+    Content is a list of {'type': 'tool_reference', 'tool_name': '...'} dicts,
+    or a stringified repr of same. Returns None if the shape doesn't match.
+    """
+    items = content
+    if isinstance(content, str):
+        if not content.strip().startswith("[{"):
+            return None
+        try:
+            import ast
+
+            items = ast.literal_eval(content)
+        except (ValueError, SyntaxError):
+            return None
+    if not isinstance(items, list):
+        return None
+    names = [
+        item["tool_name"]
+        for item in items
+        if isinstance(item, dict)
+        and item.get("type") == "tool_reference"
+        and item.get("tool_name")
+    ]
+    return names or None
+
+
 def format_agent_prompt(prompt: str) -> tuple[str, bool]:
     """Format inter-agent prompts for nicer display.
 
@@ -179,6 +212,11 @@ def format_result_summary(name: str, content: str, is_error: bool = False) -> st
     elif name == ToolName.WRITE:
         return "(done)"
 
+    elif name == ToolName.TOOL_SEARCH:
+        names = extract_tool_search_names(content)
+        count = len(names) if names else content.count("<function>")
+        return f"({count} tools)" if count else ""
+
     return ""
 
 
@@ -232,6 +270,14 @@ def format_tool_header(name: str, input: dict, cwd: Path | None = None) -> str:
         return "AskUserQuestion"
     elif name == ToolName.SKILL:
         return f"Skill: {input.get('skill', '?')}"
+    elif name == ToolName.TOOL_SEARCH:
+        query = input.get("query", "?")
+        if query.startswith("select:"):
+            names = (n.strip() for n in query[len("select:") :].split(","))
+            query = ", ".join(strip_mcp_prefix(n) for n in names if n)
+        max_results = input.get("max_results")
+        suffix = f" (max {max_results})" if max_results and max_results != 5 else ""
+        return f"ToolSearch: {query}{suffix}"
     elif name == ToolName.ENTER_PLAN_MODE:
         return "EnterPlanMode"
     elif name == ToolName.EXIT_PLAN_MODE:

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -14,10 +14,12 @@ from textual.widgets import Markdown, Static
 
 from claudechic.enums import ToolName
 from claudechic.formatting import (
+    extract_tool_search_names,
     format_result_summary,
     format_tool_header,
     format_tool_input,
     make_relative,
+    strip_mcp_prefix,
 )
 from claudechic.widgets.base.tool_base import BaseToolWidget
 from claudechic.widgets.content.diff import DiffWidget
@@ -128,6 +130,13 @@ class ToolUseWidget(BaseToolWidget):
                     yield Static("(Plan content not available)", id="tool-output")
                 if self._plan_path:
                     yield Button("📋 Edit Plan", classes="edit-plan-btn")
+            return
+        # ToolSearch: title summarizes query; body only shows loaded tools
+        if self.block.name == ToolName.TOOL_SEARCH:
+            with QuietCollapsible(
+                title=self._header, collapsed=self._initial_collapsed
+            ):
+                yield Static("", id="tool-output", markup=False)
             return
         # Edit tool: use lazy content when collapsed (DiffWidget is expensive)
         if self.block.name == ToolName.EDIT:
@@ -268,6 +277,16 @@ class ToolUseWidget(BaseToolWidget):
                     output_widget.update(preview)
                 elif self.block.name == ToolName.ENTER_PLAN_MODE:
                     output_widget.update("Entered plan mode")
+                elif self.block.name == ToolName.TOOL_SEARCH:
+                    names = extract_tool_search_names(result.content)
+                    if names:
+                        lines = [
+                            Text.assemble(("+ ", "green"), strip_mcp_prefix(n))
+                            for n in names
+                        ]
+                        output_widget.update(Text("\n").join(lines))
+                    else:
+                        output_widget.update(f"{preview}{trunc_suffix}")
                 else:
                     output_widget.update(f"{preview}{trunc_suffix}")
         except Exception:

--- a/tests/test_threading_excepthook.py
+++ b/tests/test_threading_excepthook.py
@@ -1,0 +1,93 @@
+"""Regression test for the threading excepthook.
+
+The hook is invoked by the Python runtime when an unhandled exception
+escapes a thread. The runtime passes a `threading.ExceptHookArgs`
+named-tuple whose traceback field is `exc_traceback` (NOT `exc_tb`). A
+previous version of the hook accessed `args.exc_tb`, which raises
+AttributeError and silently swallows the real underlying thread exception.
+
+Imports from `claudechic.errors` rather than `claudechic.__main__` to avoid
+triggering __main__'s module-level `setup_logging()` side effect, which
+sets `propagate=False` on the `claudechic` logger and would break pytest's
+`caplog` fixture for every subsequent test in the same xdist worker.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from claudechic.errors import threading_excepthook
+
+
+class _CaptureHandler(logging.Handler):
+    """Test handler that records all emitted records."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _attach_capture():
+    """Attach a capture handler to the `claudechic` logger.
+
+    Robust to either propagate state: if some other test in the same
+    worker has triggered `setup_logging()` (which sets propagate=False),
+    `caplog` (rooted at the root logger) wouldn't see records. Attaching
+    directly to the package logger sidesteps that.
+    """
+    capture = _CaptureHandler()
+    capture.setLevel(logging.CRITICAL)
+    logger = logging.getLogger("claudechic")
+    logger.addHandler(capture)
+    return capture, logger
+
+
+def test_threading_excepthook_handles_real_thread_exception():
+    """The hook must consume an ExceptHookArgs from a real thread without
+    raising. Regression for the `args.exc_tb` typo."""
+    capture, logger = _attach_capture()
+    original = threading.excepthook
+    threading.excepthook = threading_excepthook
+    try:
+
+        def boom():
+            raise ValueError("intentional thread crash for test")
+
+        t = threading.Thread(target=boom, name="excepthook-test-thread")
+        t.start()
+        t.join(timeout=2.0)
+    finally:
+        threading.excepthook = original
+        logger.removeHandler(capture)
+
+    # The critical log entry must be present, with the real exception attached.
+    matching = [
+        rec
+        for rec in capture.records
+        if rec.levelname == "CRITICAL"
+        and rec.exc_info is not None
+        and rec.exc_info[0] is ValueError
+    ]
+    assert matching, (
+        "Expected a CRITICAL log record with ValueError exc_info; "
+        "got records: "
+        + repr([(r.levelname, r.getMessage(), r.exc_info) for r in capture.records])
+    )
+
+
+def test_threading_excepthook_skips_keyboard_interrupt():
+    """KeyboardInterrupt in a thread must not be logged as a critical error."""
+    capture, logger = _attach_capture()
+    try:
+        args = threading.ExceptHookArgs(
+            [KeyboardInterrupt, KeyboardInterrupt(), None, threading.current_thread()]
+        )
+        threading_excepthook(args)
+    finally:
+        logger.removeHandler(capture)
+
+    assert not any(rec.levelname == "CRITICAL" for rec in capture.records)


### PR DESCRIPTION
Mirrors #44 (already merged to \`develop\`) onto \`main\`. Same diff, same content — needed because \`develop -> main\` direct merges trip the \`.project_team/\` guard, and the threading-excepthook fix is currently broken in any \`main\`-installed copy of claudechic on Python 3.14.

The user reported the install at \`C:\\Users\\moharb\\AppData\\Roaming\\uv\\tools\\claudechic\\Lib\\site-packages\\claudechic\\__main__.py:38\` still has the broken \`args.exc_tb\` line — that's because the install pulls from \`main\`, which never received the fix from #44.

## What's in this mirror
1. **Render ToolSearch tool uses compactly** (cherry-pick of upstream \`e893a8c\`)
2. **fix(__main__): use ExceptHookArgs.exc_traceback (not .exc_tb)** — plus \`tests/test_threading_excepthook.py\`
3. **fix(errors): move excepthook defs out of __main__** — keeps the test from poisoning \`caplog\` for the rest of the worker via \`setup_logging()\`'s \`propagate=False\` side effect

## Test plan
- [x] Cherry-pick from develop applied cleanly
- [x] No \`.project_team/\` paths touched
- [x] Confirmed \`args.exc_traceback\` is the live attribute reference (errors.py:169)
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)