### PR TITLE
fix(commands): render /context via SDK get_context_usage() (TUI was blank)

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -30,6 +30,9 @@ from claude_agent_sdk import (
     ToolUseBlock,
     UserMessage,
 )
+from claude_agent_sdk import (
+    TextBlock as SDKTextBlock,
+)  # local TextBlock (line 91) is the chat-history dataclass
 from claude_agent_sdk.types import (
     PermissionResult,
     PermissionResultAllow,
@@ -1000,23 +1003,23 @@ Key Rules:
             if message.uuid:
                 self.checkpoint_uuids.append(message.uuid)
 
-            # UserMessage can contain tool results or command output
+            # UserMessage content is ``str | list[ContentBlock]`` per the
+            # SDK typing. Both shapes are scanned for the SDK-side
+            # ``<command-name>/...</command-name>`` marker so we can
+            # clear pending slash-command tracking when the SDK resolves
+            # a command as a skill. (``/context``-style local-command
+            # output is handled in commands.py via
+            # ``ClaudeSDKClient.get_context_usage()``; the SDK does not
+            # deliver that envelope on receive_response.)
             content = getattr(message, "content", "")
             if isinstance(content, str):
-                # Handle local command output (e.g., /context)
-                if "<local-command-stdout>" in content:
-                    self._handle_command_output(content)
-                # Detect SDK-loaded skills (e.g., /cleanup -> <command-name>/cleanup</command-name>)
-                if "<command-name>/" in content:
-                    match = re.search(
-                        r"<command-name>(/[\w:-]+)</command-name>", content
-                    )
-                    if match and self.observer:
-                        self.observer.on_skill_loaded(self, match.group(1))
+                self._scan_user_text_for_commands(content)
             elif isinstance(content, list):
                 for block in content:
                     if isinstance(block, ToolResultBlock):
                         self._handle_tool_result(block)
+                    elif isinstance(block, SDKTextBlock):
+                        self._scan_user_text_for_commands(block.text)
 
         elif isinstance(message, StreamEvent):
             self._handle_stream_event(message)
@@ -1129,16 +1132,30 @@ Key Rules:
                 item.metadata.cost_usd = result.total_cost_usd
                 break
 
-    def _handle_command_output(self, content: str) -> None:
-        """Handle command output from UserMessage (e.g., /context)."""
-        import re
+    def _scan_user_text_for_commands(self, text: str) -> None:
+        """Detect SDK-side ``<command-name>/...</command-name>`` notices.
 
-        # Extract content from <local-command-stdout>...</local-command-stdout>
-        match = re.search(
-            r"<local-command-stdout>(.*?)</local-command-stdout>", content, re.DOTALL
-        )
-        if match and self.observer:
-            self.observer.on_command_output(self, match.group(1).strip())
+        The SDK emits this marker when a slash command resolves as a
+        skill; forwarding the slash-command name to
+        ``observer.on_skill_loaded`` lets claudechic clear pending
+        slash-command tracking.
+
+        Called from both ``str`` and ``list[TextBlock]`` content shapes
+        of ``UserMessage`` so the SDK's payload-shape choice is
+        invisible to callers.
+
+        Note: an earlier version of this helper also extracted
+        ``<local-command-stdout>...</local-command-stdout>`` envelopes
+        for ``/context``-style rendering. That envelope is no longer
+        delivered on receive_response under current claude-agent-sdk
+        versions (the SDK strips it via ``transcript_mirror``);
+        ``/context`` is now intercepted in commands.py and rendered
+        via the SDK's ``get_context_usage()`` API.
+        """
+        if "<command-name>/" in text:
+            match = re.search(r"<command-name>(/[\w:-]+)</command-name>", text)
+            if match and self.observer:
+                self.observer.on_skill_loaded(self, match.group(1))
 
     def _handle_tool_use(
         self, block: ToolUseBlock, parent_tool_use_id: str | None

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -9,6 +9,7 @@ It's used by autocomplete (app.py) and help (help_data.py).
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import time
@@ -16,6 +17,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from claudechic.analytics import capture
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from claudechic.app import ChatApp
@@ -313,6 +316,11 @@ def handle_command(app: ChatApp, prompt: str) -> bool:
         context = cmd.split(maxsplit=1)[1] if cmd.startswith("/reviewer ") else None
         return _handle_review(app, context)
 
+    if cmd == "/context":
+        _track_command(app, "context")
+        app.run_worker(_handle_context(app))
+        return True
+
     if cmd == "/help":
         _track_command(app, "help")
         app.run_worker(_handle_help(app))
@@ -447,11 +455,18 @@ CLAUDE_CLI_COMMANDS = frozenset(
     }
 )
 
-# Built-in SDK commands that work in claudechic (pass through, no tracking)
+# Built-in SDK commands that work in claudechic (pass through, no tracking).
+# NB: /context is NOT in this set. Although the SDK's CLI processes /context
+# locally, it emits the output via "transcript_mirror" frames that
+# claude_agent_sdk silently strips from receive_response (see
+# claude_agent_sdk/_internal/query.py:280) and only writes to the session
+# JSONL on disk. Result: no SDK message reaches claudechic for the TUI to
+# render. Instead we intercept /context here and call
+# ClaudeSDKClient.get_context_usage() directly -- same data, no roundtrip,
+# no transcript_mirror dance.
 SDK_PASSTHROUGH_COMMANDS = frozenset(
     {
         "/compact",
-        "/context",
         "/init",
         "/ultrareview",  # Cloud-based parallel multi-agent review (Claude Code 2.1.111+)
     }
@@ -825,6 +840,71 @@ async def _handle_help(app: ChatApp) -> None:
         msg.add_class("system-message")
         chat_view.mount(msg)
         chat_view.scroll_if_tailing()
+
+
+async def _handle_context(app: ChatApp) -> None:
+    """Render /context via the SDK's get_context_usage() API.
+
+    The CLI's built-in /context command writes its markdown output via
+    ``transcript_mirror`` frames that the SDK strips from the consumer
+    stream (see claude_agent_sdk/_internal/query.py:280); the markdown
+    only ever lands in the session JSONL on disk. So forwarding /context
+    to the SDK as a normal prompt produces nothing the TUI can render.
+
+    Instead we call ``ClaudeSDKClient.get_context_usage()`` -- the same
+    structured data the CLI uses internally -- format it as the markdown
+    that ``ContextReport.parse_context_markdown`` already understands,
+    and post a ``CommandOutputMessage``. The existing
+    ``on_command_output_message`` handler then mounts the colored
+    ``ContextReport`` widget unchanged.
+    """
+    from claudechic.messages import CommandOutputMessage
+
+    agent = app._agent
+    if agent is None or agent.client is None:
+        app.notify("No active agent for /context", severity="warning")
+        return
+
+    try:
+        usage = await agent.client.get_context_usage()
+    except Exception as exc:
+        log.exception("get_context_usage failed")
+        app.notify(f"/context failed: {exc}", severity="error")
+        return
+
+    total = int(usage.get("totalTokens") or 0)
+    max_tokens = int(usage.get("maxTokens") or usage.get("rawMaxTokens") or 0)
+    pct = float(usage.get("percentage") or 0.0)
+    model = usage.get("model") or ""
+    categories = usage.get("categories") or []
+
+    # ContextReport.parse_context_markdown reads:
+    #   "**Model:** <name>"
+    #   "**Tokens:** <used> / <max> (<pct>%)" -- with optional k/m suffixes
+    #   "| <name> | <tokens>[k|m] | <pct>% |" rows
+    # Use plain integer counts so the parser's `[\d.]+[kmKM]?` accepts
+    # them (suffix is optional). Percentage is per-category share of
+    # max_tokens to match the existing display semantics.
+    denom = max_tokens or total or 1
+    lines = [
+        "## Context Usage",
+        "",
+        f"**Model:** {model}",
+        f"**Tokens:** {total} / {max_tokens} ({pct:.0f}%)",
+        "",
+        "| Category | Tokens | Percentage |",
+        "|----------|--------|------------|",
+    ]
+    for cat in categories:
+        if not isinstance(cat, dict):
+            continue
+        name = str(cat.get("name") or "")
+        tokens = int(cat.get("tokens") or 0)
+        cat_pct = (tokens / denom * 100) if denom else 0.0
+        lines.append(f"| {name} | {tokens} | {cat_pct:.1f}% |")
+
+    content = "\n".join(lines)
+    app.post_message(CommandOutputMessage(content, agent_id=agent.id))
 
 
 def _handle_processes(app: ChatApp) -> None:


### PR DESCRIPTION
Closes the same bug #48 was trying (and failing) to fix. Supersedes #48.

## The bug
\`/context\` rendered nothing in the claudechic TUI. The same markdown still leaked into the model's transcript on the next turn, but the user saw a blank chat view.

## Why the previous attempt missed
\`/context\` was in \`SDK_PASSTHROUGH_COMMANDS\`, so claudechic forwarded it to the SDK as a normal prompt. The original detection code in \`agent.py\` looked for a \`<local-command-stdout>...</local-command-stdout>\` envelope inside an incoming \`UserMessage\` and routed the inner content to a \`CommandOutputMessage\` for \`ContextReport\` to render.

That hadn't worked for at least one SDK version, but it wasn't visible because the test (\`test_context_report_displays\`) injected \`CommandOutputMessage\` directly and skipped the upstream extraction.

Diagnostic logging on the live agent (now removed) showed the CLI's \`/context\` output never reaches \`_handle_sdk_message\` at all under claude-agent-sdk 0.1.68. The SDK peels \`transcript_mirror\` frames off stdout in \`claude_agent_sdk/_internal/query.py:280\` and explicitly drops them from the consumer stream -- the markdown only ever lands in the session JSONL on disk. So the entire \`_handle_command_output\` extractor was dead code under the current SDK.

## The fix
Skip the SDK roundtrip entirely.

- Remove \`/context\` from \`SDK_PASSTHROUGH_COMMANDS\`.
- Add an explicit \`/context\` dispatch in \`handle_command\` that schedules a worker.
- The worker (\`_handle_context\`) calls \`ClaudeSDKClient.get_context_usage()\` -- the SDK's structured equivalent of the CLI's \`/context\` -- and formats the response as the markdown that \`ContextReport.parse_context_markdown\` already understands. Posts a \`CommandOutputMessage\`.
- The existing \`on_command_output_message\` handler detects \`## Context Usage\` and mounts the colored \`ContextReport\` widget unchanged.

## Cleanup in \`agent.py\`
- Drop \`_handle_command_output\` (dead under the current SDK delivery model).
- Refactor the surviving \`<command-name>/...</command-name>\` skill detection into \`_scan_user_text_for_commands\`, called from BOTH the \`str\` and \`list[TextBlock]\` \`UserMessage.content\` shapes so the SDK's payload-shape choice is invisible.

## Files
- \`claudechic/commands.py\` -- \`/context\` removed from passthrough; new \`_handle_context\` worker; logger added.
- \`claudechic/agent.py\` -- \`_handle_command_output\` removed; \`_scan_user_text_for_commands\` simplified to skill-marker detection; list-shape \`TextBlock\` scanning added.

Net diff: 2 files, +120 / -23.

## Test plan
- [x] \`ruff check\` / \`ruff format\` clean
- [x] \`pyright claudechic/commands.py claudechic/agent.py\` -- 0 errors
- [x] \`pytest tests/ -n auto --timeout=30\` -- 870 passed (the one failure observed under heavy parallel load passes on isolated rerun; same pattern as recent PRs)
- [x] **Manual confirmation**: I tested locally inside claudechic TUI; \`/context\` now renders the colored grid + legend immediately on each invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)