### PR TITLE
fix(cluster): tier-aware cluster.yaml loading + scope CI to main (#50)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,17 @@
 name: Tests
-on: [push, pull_request]
+# Triggers are scoped to main so feature-branch and develop pushes do not burn
+# matrix minutes. CI fires only on PRs targeting main (the gate that actually
+# blocks releases) and on push-to-main itself (catches the post-merge SHA --
+# squash/merge-commit/rebase strategies all produce a new SHA that the PR's CI
+# never tested). workflow_dispatch lets a maintainer rerun the suite manually
+# on any branch when needed (smoke-testing develop before promoting it,
+# re-running a known flake, etc.).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 # Dedup the push+pull_request double-trigger: when you push a branch and open
 # a PR for it, both events fire for the same SHA, doubling matrix jobs (24

--- a/claudechic/defaults/mcp_tools/cluster.yaml
+++ b/claudechic/defaults/mcp_tools/cluster.yaml
@@ -1,8 +1,18 @@
-# Cluster configuration -- populated by cluster-setup workflow
+# Cluster configuration -- SCHEMA REFERENCE ONLY.
+#
+# This bundled file is NOT loaded at runtime. The cluster MCP tools
+# read config from project tier (<cwd>/.claudechic/mcp_tools/cluster.yaml)
+# or user tier (~/.claudechic/mcp_tools/cluster.yaml). See issue #50.
+#
+# Editing this file in place will NOT take effect, and `uv tool upgrade
+# claudechic` will overwrite it. Use the cluster_setup workflow to
+# write a real config to the project tier.
+#
+# Valid keys (with example values shown after the colon):
 backend: ""              # lsf | slurm
-ssh_target: ""
-lsf_profile: ""
-watch_poll_interval: 30
-remote_cwd: ""
-path_map: []
-log_access: auto
+ssh_target: ""           # cluster login node hostname (e.g. submit.example.org)
+lsf_profile: ""          # path to LSF profile script on the cluster (LSF only)
+watch_poll_interval: 30  # seconds between cluster_watch polls
+remote_cwd: ""           # override working directory on the cluster
+path_map: []             # list of {local: ..., cluster: ...} mappings
+log_access: auto         # auto | local | ssh

--- a/claudechic/defaults/mcp_tools/cluster_dispatch.py
+++ b/claudechic/defaults/mcp_tools/cluster_dispatch.py
@@ -41,9 +41,49 @@ _BACKENDS = ("lsf", "slurm")
 # ---------------------------------------------------------------------------
 
 
+def _config_candidates() -> list[Path]:
+    """Return cluster.yaml lookup paths in priority order.
+
+    Two tiers, project first then user:
+
+    1. Project tier: ``<cwd>/.claudechic/mcp_tools/cluster.yaml``
+    2. User tier:    ``~/.claudechic/mcp_tools/cluster.yaml``
+
+    The first existing file wins. ``Path.cwd()`` is read fresh on every
+    call so changing the launch directory takes effect without a
+    restart of the in-process MCP server.
+
+    Note: there is intentionally NO package-tier fallback. The bundled
+    ``claudechic/defaults/mcp_tools/cluster.yaml`` is a *schema example*
+    only -- it ships with empty placeholder values and is overwritten
+    by every ``uv tool upgrade``. Reading it would either be
+    indistinguishable from returning ``{}`` (template still empty) or
+    silently load stale in-place edits that an upgrade is about to
+    clobber. See issue #50 for the bug that motivated removing it.
+    """
+    return [
+        Path.cwd() / ".claudechic" / "mcp_tools" / "cluster.yaml",
+        Path.home() / ".claudechic" / "mcp_tools" / "cluster.yaml",
+    ]
+
+
 def _load_dispatch_config() -> dict:
-    """Load cluster config from the sibling cluster.yaml file."""
-    return _load_config(Path(__file__).parent / "cluster.py")
+    """Load cluster config in tier order: project > user.
+
+    Walks :func:`_config_candidates` and returns the contents of the
+    first file that exists. Returns ``{}`` when neither tier has a
+    config -- the cluster tools then surface a "not configured" message
+    that points the user at the ``cluster_setup`` workflow. The bundled
+    package YAML is intentionally NOT consulted (see
+    :func:`_config_candidates` for rationale).
+    """
+    for path in _config_candidates():
+        if path.is_file():
+            # ``_load_config`` takes the .py path and reads its sibling
+            # .yaml. We already have the .yaml path, so flip the suffix
+            # back to keep using the shared helper for the actual read.
+            return _load_config(path.with_suffix(".py"))
+    return {}
 
 
 def _not_configured_response() -> dict[str, Any]:

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup.yaml
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup.yaml
@@ -9,10 +9,10 @@ phases:
         lifecycle: show-once
     advance_checks:
       - type: file-content-check
-        path: "mcp_tools/cluster.yaml"
+        path: ".claudechic/mcp_tools/cluster.yaml"
         pattern: "ssh_target:\\s+\\S+"
         on_failure:
-          message: "ssh_target must be set in mcp_tools/cluster.yaml before advancing."
+          message: "ssh_target must be set in .claudechic/mcp_tools/cluster.yaml before advancing."
           severity: warning
       - type: manual-confirm
         prompt: "SSH target confirmed and passwordless SSH working?"
@@ -33,10 +33,10 @@ phases:
         lifecycle: show-once
     advance_checks:
       - type: file-content-check
-        path: "mcp_tools/cluster.yaml"
+        path: ".claudechic/mcp_tools/cluster.yaml"
         pattern: "backend:\\s+(lsf|slurm)"
         on_failure:
-          message: "backend must be set to 'lsf' or 'slurm' in mcp_tools/cluster.yaml before advancing."
+          message: "backend must be set to 'lsf' or 'slurm' in .claudechic/mcp_tools/cluster.yaml before advancing."
           severity: warning
       - type: manual-confirm
         prompt: "Scheduler detected and working?"
@@ -64,7 +64,7 @@ phases:
   - id: apply
     file: apply
     hints:
-      - message: "Phase 6/6: Apply. Write the validated configuration to mcp_tools/cluster.yaml."
+      - message: "Phase 6/6: Apply. Write the validated configuration to .claudechic/mcp_tools/cluster.yaml."
         lifecycle: show-once
     advance_checks:
       - type: manual-confirm

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/apply.md
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/apply.md
@@ -1,7 +1,18 @@
 # Phase 7: Apply Configuration
 
 ## Goal
-Write the validated configuration to `mcp_tools/cluster.yaml`.
+Write the validated configuration to `.claudechic/mcp_tools/cluster.yaml` (project-tier).
+
+The cluster MCP tools resolve their config in priority order:
+1. Project tier: `<cwd>/.claudechic/mcp_tools/cluster.yaml`
+2. User tier:    `~/.claudechic/mcp_tools/cluster.yaml`
+
+If neither file exists, the tools report "not configured" and point the
+user back to this workflow. The bundled file inside the install dir is
+NOT loaded at runtime (it is a schema reference only) and `uv tool
+upgrade claudechic` overwrites it -- never edit it. Always write to
+the project tier unless the user explicitly asks for the user tier
+(cross-project default).
 
 ## Steps
 
@@ -11,7 +22,7 @@ Show the user a diff of what will change:
 - Format as a clear before/after comparison
 
 ### 2. Apply (only after user approves preview)
-Write the following fields to `mcp_tools/cluster.yaml`:
+Write the following fields to `.claudechic/mcp_tools/cluster.yaml`:
 - `backend` — detected scheduler (`lsf` or `slurm`)
 - `ssh_target` — confirmed login node
 - `lsf_profile` — scheduler profile path (LSF only, leave empty for SLURM)
@@ -25,7 +36,7 @@ Write the following fields to `mcp_tools/cluster.yaml`:
 - **Reject if validation hasn't passed.** Do not write config if phase 6 was skipped or failed.
 
 ### 3. Verify
-After writing, read back `mcp_tools/cluster.yaml` and confirm the values are correct.
+After writing, read back `.claudechic/mcp_tools/cluster.yaml` and confirm the values are correct.
 
 ### 4. Test
 Submit a quick test job via `cluster_submit` to confirm everything works end-to-end:

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/detect.md
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/detect.md
@@ -15,7 +15,7 @@ Determine how the user connects to the cluster, verify reachability, and confirm
    - If a likely match is found, propose it as the ssh_target
 
 3. **Check existing config:**
-   - Read `mcp_tools/cluster.yaml` for `ssh_target`
+   - Read `.claudechic/mcp_tools/cluster.yaml` for `ssh_target` (project tier)
    - If set, test reachability with passwordless SSH:
      ```
      ssh -o BatchMode=yes -o ConnectTimeout=5 <target> echo ok
@@ -40,7 +40,7 @@ Determine how the user connects to the cluster, verify reachability, and confirm
 Report: `{status: configured|missing|unreachable|auth_failed|skipped, ssh_target, local_scheduler, os_platform, passwordless_ssh: true|false}`
 
 ## Before advancing
-**Write `ssh_target` to `mcp_tools/cluster.yaml`** — the advance check requires it. Use Edit to set the confirmed hostname before calling `advance_phase`.
+**Write `ssh_target` to `.claudechic/mcp_tools/cluster.yaml`** (project tier) — the advance check requires it. Use Edit to set the confirmed hostname before calling `advance_phase`.
 
 **Important: Do NOT quote the value.** Write `ssh_target: submit.int.janelia.org` not `ssh_target: "submit.int.janelia.org"`. The advance checks use `awk '/^ssh_target:/{print $2}'` to extract the value, and quotes would be included literally, causing SSH to fail with "hostname contains invalid characters".
 

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/identity.md
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/identity.md
@@ -12,7 +12,9 @@ You are a guided cluster configuration agent. Your job is to detect the user's e
 
 ## Config Target
 
-All configuration is written to `mcp_tools/cluster.yaml`. The key fields:
+All configuration is written to `.claudechic/mcp_tools/cluster.yaml` (project tier). At runtime the cluster MCP tools resolve config in priority order: project (`<cwd>/.claudechic/mcp_tools/cluster.yaml`) > user (`~/.claudechic/mcp_tools/cluster.yaml`). The bundled file in the install dir is a schema reference only and is overwritten by `uv tool upgrade`.
+
+The key fields:
 - `backend` — scheduler type (`lsf` or `slurm`), detected in phase 4
 - `ssh_target` — cluster login node hostname
 - `lsf_profile` — path to LSF profile script (LSF only)

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/scheduler.md
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup_helper/scheduler.md
@@ -25,7 +25,7 @@ Detect which job scheduler (LSF or SLURM) is available on the cluster.
    - `ssh <target> 'test -f /misc/lsf/conf/profile.lsf && echo exists'`
 
 ## Before advancing
-**Write `backend` and `lsf_profile` to `mcp_tools/cluster.yaml`** before calling `advance_phase`. The next phases rely on these values. Example for LSF:
+**Write `backend` and `lsf_profile` to `.claudechic/mcp_tools/cluster.yaml`** (project tier) before calling `advance_phase`. The next phases rely on these values. Example for LSF:
 ```yaml
 backend: lsf
 lsf_profile: /misc/lsf/conf/profile.lsf

--- a/tests/test_cluster_config_tier_resolution.py
+++ b/tests/test_cluster_config_tier_resolution.py
@@ -1,0 +1,278 @@
+"""Regression test for issue #50: cluster.yaml tier-aware loading.
+
+The cluster MCP tools (cluster_submit, cluster_jobs, etc.) used to read
+their backend YAML from ``Path(__file__).parent / "cluster.yaml"`` --
+always the bundled file inside the install dir. Site-specific config
+drops at ``<cwd>/.claudechic/mcp_tools/cluster.yaml`` were silently
+ignored, and ``uv tool upgrade claudechic`` would clobber any in-place
+edits.
+
+This test launches the real TUI in a temp directory that contains a
+project-tier ``.claudechic/mcp_tools/cluster.yaml`` and asserts that
+the loader picks up the project YAML rather than the bundled fallback.
+The bundled package YAML always exists (it ships with the install), so
+"both YAMLs are there" is satisfied by construction; the test is
+concerned with which one wins.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+from claudechic.app import ChatApp
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_MCP_TOOLS_DIR = REPO_ROOT / "claudechic" / "defaults" / "mcp_tools"
+BUNDLED_YAML = PKG_MCP_TOOLS_DIR / "cluster.yaml"
+
+
+# Distinctive project-tier config -- nothing in the bundled YAML should
+# match these values, so a successful read proves the project file won.
+PROJECT_CONFIG = {
+    "backend": "lsf",
+    "ssh_target": "submit.example.org",
+    "lsf_profile": "/misc/lsf/conf/profile.lsf",
+    "watch_poll_interval": 7,
+    "remote_cwd": "/scratch/test-project-tier",
+    "path_map": [{"local": "/data", "cluster": "/nrs/data"}],
+    "log_access": "ssh",
+}
+
+
+def _write_project_cluster_yaml(project_root: Path) -> Path:
+    """Create ``<project_root>/.claudechic/mcp_tools/cluster.yaml``."""
+    project_yaml_dir = project_root / ".claudechic" / "mcp_tools"
+    project_yaml_dir.mkdir(parents=True, exist_ok=True)
+    project_yaml = project_yaml_dir / "cluster.yaml"
+    project_yaml.write_text(yaml.safe_dump(PROJECT_CONFIG), encoding="utf-8")
+    return project_yaml
+
+
+def _load_cluster_dispatch_module() -> types.ModuleType:
+    """Import the bundled ``cluster_dispatch.py`` against the in-test
+    helper namespace, mirroring the production loader in ``mcp.py``."""
+    if "mcp_tools" not in sys.modules:
+        sys.modules["mcp_tools"] = types.ModuleType("mcp_tools")
+
+    if "mcp_tools._cluster" not in sys.modules:
+        helper_file = PKG_MCP_TOOLS_DIR / "_cluster.py"
+        spec = importlib.util.spec_from_file_location("mcp_tools._cluster", helper_file)
+        assert spec is not None and spec.loader is not None
+        helper_mod = importlib.util.module_from_spec(spec)
+        sys.modules["mcp_tools._cluster"] = helper_mod
+        spec.loader.exec_module(helper_mod)
+
+    dispatch_file = PKG_MCP_TOOLS_DIR / "cluster_dispatch.py"
+    spec = importlib.util.spec_from_file_location(
+        "mcp_tools.cluster_dispatch_tier_test", dispatch_file
+    )
+    assert spec is not None and spec.loader is not None
+    dispatch_mod = importlib.util.module_from_spec(spec)
+    sys.modules["mcp_tools.cluster_dispatch_tier_test"] = dispatch_mod
+    spec.loader.exec_module(dispatch_mod)
+    return dispatch_mod
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight sanity (unit level)
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_yaml_has_distinct_content() -> None:
+    """Sanity: the bundled YAML must not coincidentally match the
+    project-tier fixture, otherwise downstream assertions cannot tell
+    which file was loaded."""
+    assert BUNDLED_YAML.is_file(), "bundled cluster.yaml must ship in defaults/"
+    bundled = yaml.safe_load(BUNDLED_YAML.read_text(encoding="utf-8")) or {}
+    # The shipped default leaves all site-specific keys empty.
+    assert bundled.get("backend", "") != PROJECT_CONFIG["backend"]
+    assert bundled.get("ssh_target", "") != PROJECT_CONFIG["ssh_target"]
+
+
+def test_config_candidates_priority_order(monkeypatch, tmp_path) -> None:
+    """``_config_candidates()`` lists project tier first, then user. The
+    bundled package YAML is intentionally NOT a candidate (issue #50):
+    it is a schema reference, not a runtime config source, because
+    ``uv tool upgrade claudechic`` clobbers any in-place edits."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+
+    mod = _load_cluster_dispatch_module()
+    candidates = mod._config_candidates()
+
+    assert candidates == [
+        tmp_path / ".claudechic" / "mcp_tools" / "cluster.yaml",
+        home / ".claudechic" / "mcp_tools" / "cluster.yaml",
+    ]
+    # Belt-and-suspenders: prove the bundled path is not snuck in.
+    assert PKG_MCP_TOOLS_DIR / "cluster.yaml" not in candidates
+
+
+def test_load_dispatch_config_returns_empty_when_no_tier_config(
+    monkeypatch, tmp_path
+) -> None:
+    """With no project- and no user-tier file, the loader returns ``{}``
+    -- NOT the bundled placeholder. This is the contract that lets the
+    cluster tools surface "not configured" cleanly instead of silently
+    loading stale install-dir state.
+
+    The bundled YAML on disk has empty placeholder values, so a buggy
+    fallback would also produce an empty-ish dict but with the schema
+    keys (``backend: ""``, ``log_access: "auto"``, etc.) populated.
+    Asserting equality with ``{}`` distinguishes the two cases."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+
+    mod = _load_cluster_dispatch_module()
+    config = mod._load_dispatch_config()
+
+    assert config == {}, (
+        "loader must NOT fall back to the bundled YAML; got "
+        f"{config!r}. The bundled file is a schema reference only."
+    )
+
+
+def test_bundled_yaml_is_documented_as_schema_only() -> None:
+    """The bundled cluster.yaml must declare itself a schema reference
+    so a future contributor reading the install dir does not assume it
+    is loaded. Pins the disclaimer text so silent edits get caught."""
+    text = BUNDLED_YAML.read_text(encoding="utf-8")
+    assert "SCHEMA REFERENCE ONLY" in text
+    assert "NOT loaded at runtime" in text
+
+
+# ---------------------------------------------------------------------------
+# Real TUI launch -- the integration test the user explicitly requested
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_real_tui_launch_loads_project_tier_cluster_yaml(
+    mock_sdk, monkeypatch, tmp_path
+) -> None:
+    """Real TUI launch in a directory containing a project-tier
+    ``.claudechic/mcp_tools/cluster.yaml``: the bundled YAML at
+    ``<install>/defaults/mcp_tools/cluster.yaml`` also exists (it ships
+    with the install) so both files are present. The dispatcher must
+    pick the project tier.
+
+    This is the end-to-end shape of issue #50: the user sets up a site
+    config, launches the TUI from the project root, and expects the
+    cluster MCP tools to honor that config rather than the bundled
+    placeholder.
+    """
+    # Isolate $HOME so a real ~/.claudechic/mcp_tools/cluster.yaml on
+    # the developer's machine doesn't override the project tier and
+    # invalidate the test premise.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+
+    project_yaml = _write_project_cluster_yaml(tmp_path)
+    assert project_yaml.is_file()
+    assert BUNDLED_YAML.is_file(), (
+        "test premise broken: bundled cluster.yaml must exist alongside "
+        "the project tier file so we can prove which one was chosen"
+    )
+
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        # Sanity: the TUI launched in our temp project root.
+        assert app._cwd == tmp_path
+
+        # The TUI's MCP discovery loads cluster_dispatch.py from the
+        # package tier under the namespaced key ``mcp_tools.package.
+        # cluster_dispatch``. Reach into sys.modules to grab the exact
+        # module instance the live MCP server is bound to, so we test
+        # the same loader path the agent would hit at tool-call time.
+        dispatch_mod = sys.modules.get("mcp_tools.package.cluster_dispatch")
+        if dispatch_mod is None:
+            # Older / alt loader paths may stash it under the legacy
+            # alias. Either is fine -- both refer to the same source
+            # file, so the layered loader logic under test is identical.
+            dispatch_mod = sys.modules.get("mcp_tools.cluster_dispatch")
+        assert dispatch_mod is not None, (
+            "cluster_dispatch.py was not loaded by the TUI's MCP "
+            "discovery; the test cannot verify the layered loader. "
+            "sys.modules keys: "
+            + ", ".join(k for k in sys.modules if "cluster_dispatch" in k)
+        )
+
+        # Drive the loader exactly like the live cluster_* tools do.
+        config = dispatch_mod._load_dispatch_config()
+
+    # Outside the run_test context the app is torn down, but the loader
+    # result is a plain dict so we can keep asserting on it.
+    assert config == PROJECT_CONFIG, (
+        "project-tier cluster.yaml was not honored by _load_dispatch_config; "
+        "this is exactly the bug from issue #50. "
+        f"Loaded config: {config!r}"
+    )
+
+    # Spot-checks against the most operationally significant fields, in
+    # case a future refactor merges configs across tiers (in which case
+    # equality may not hold but project values must still win).
+    assert config["backend"] == "lsf"
+    assert config["ssh_target"] == "submit.example.org"
+    assert config["remote_cwd"] == "/scratch/test-project-tier"
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_real_tui_launch_without_tier_config_returns_empty(
+    mock_sdk, monkeypatch, tmp_path
+) -> None:
+    """Negative companion: launching the TUI in a directory with NO
+    project- or user-tier ``cluster.yaml`` yields ``{}`` from
+    ``_load_dispatch_config()`` -- explicitly NOT the bundled YAML.
+
+    The bundled file still exists on disk inside the install dir (it
+    ships with the package as a schema reference). This test pins the
+    contract that the live MCP server does not consult it: the cluster
+    tools must surface "not configured" via empty config, not silently
+    load whatever happens to be in the install dir.
+
+    Asserting ``config == {}`` rather than just falsiness catches a
+    regression where the bundled placeholder (``backend: ""``,
+    ``log_access: "auto"``, etc.) sneaks back in -- that dict is also
+    falsy-ish but populated, so equality is the discriminating check."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+
+    # Deliberately NO project- or user-tier file written.
+    assert not (tmp_path / ".claudechic" / "mcp_tools" / "cluster.yaml").exists()
+    assert not (home / ".claudechic" / "mcp_tools" / "cluster.yaml").exists()
+    # Bundled file still on disk -- this is the file the loader is
+    # required NOT to read.
+    assert BUNDLED_YAML.is_file()
+
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        dispatch_mod = sys.modules.get(
+            "mcp_tools.package.cluster_dispatch"
+        ) or sys.modules.get("mcp_tools.cluster_dispatch")
+        assert dispatch_mod is not None
+        config = dispatch_mod._load_dispatch_config()
+
+    assert config == {}, (
+        "loader must NOT fall back to bundled YAML when no tier config "
+        f"exists; got {config!r}. Issue #50 -- the bundled file is a "
+        "schema reference, never a runtime config source."
+    )

--- a/tests/test_cluster_config_tier_resolution.py
+++ b/tests/test_cluster_config_tier_resolution.py
@@ -53,6 +53,19 @@ def _write_project_cluster_yaml(project_root: Path) -> Path:
     return project_yaml
 
 
+def _redirect_home(monkeypatch, home: Path) -> None:
+    """Point ``Path.home()`` at ``home`` on every supported OS.
+
+    POSIX reads ``$HOME``. Windows ``Path.home()`` reads ``USERPROFILE``
+    first (then ``HOMEDRIVE`` + ``HOMEPATH``), so setting only ``HOME``
+    is a no-op on Windows and leaves the user-tier candidate pointing
+    at the real account dir -- which on CI is ``C:/Users/runneradmin``
+    and tainted whatever the test thought it was isolating. Setting
+    both env vars covers Linux, macOS, and Windows uniformly."""
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def _load_cluster_dispatch_module() -> types.ModuleType:
     """Import the bundled ``cluster_dispatch.py`` against the in-test
     helper namespace, mirroring the production loader in ``mcp.py``."""
@@ -101,7 +114,7 @@ def test_config_candidates_priority_order(monkeypatch, tmp_path) -> None:
     ``uv tool upgrade claudechic`` clobbers any in-place edits."""
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _redirect_home(monkeypatch, home)
     monkeypatch.chdir(tmp_path)
 
     mod = _load_cluster_dispatch_module()
@@ -129,7 +142,7 @@ def test_load_dispatch_config_returns_empty_when_no_tier_config(
     Asserting equality with ``{}`` distinguishes the two cases."""
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _redirect_home(monkeypatch, home)
     monkeypatch.chdir(tmp_path)
 
     mod = _load_cluster_dispatch_module()
@@ -176,7 +189,7 @@ async def test_real_tui_launch_loads_project_tier_cluster_yaml(
     # invalidate the test premise.
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _redirect_home(monkeypatch, home)
     monkeypatch.chdir(tmp_path)
 
     project_yaml = _write_project_cluster_yaml(tmp_path)
@@ -251,7 +264,7 @@ async def test_real_tui_launch_without_tier_config_returns_empty(
     falsy-ish but populated, so equality is the discriminating check."""
     home = tmp_path / "home"
     home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
+    _redirect_home(monkeypatch, home)
     monkeypatch.chdir(tmp_path)
 
     # Deliberately NO project- or user-tier file written.


### PR DESCRIPTION
## Summary

Two changes bundled per maintainer request:

### 1. Issue #50: tier-aware `cluster.yaml` loading

- Cluster MCP tools now read `cluster.yaml` from project tier (`<cwd>/.claudechic/mcp_tools/cluster.yaml`) and user tier (`~/.claudechic/mcp_tools/cluster.yaml`) instead of the install dir's bundled file.
- Bundled package fallback dropped entirely. The bundled YAML is reframed as a `SCHEMA REFERENCE ONLY` -- it is no longer a runtime config source, so `uv tool upgrade claudechic` can no longer silently clobber a working config.
- `cluster_setup` workflow updated end-to-end: advance-check paths, hint messages, `apply.md`, `detect.md`, `scheduler.md`, `identity.md` all point at the project-tier path and explain the priority order.

### 2. CI trigger scope (`.github/workflows/test.yml`)

- Drops push-on-any-branch and PR-on-any-base. CI now fires only on:
  - `pull_request` with `base: main` (the gate that actually blocks releases)
  - `push` to `main` (catches the post-merge SHA that PR CI never saw -- squash/merge-commit/rebase all produce new SHAs)
  - `workflow_dispatch` (manual rerun on any branch when needed)
- Eliminates wasted matrix runs on develop pushes, feature-branch WIP pushes, and PRs targeting develop.
- Existing concurrency group continues to dedup push+PR on the merge.

## Test plan

- [x] `pytest tests/test_cluster_config_tier_resolution.py` -- 6 tests, including two real `ChatApp.run_test()` launches (one with project-tier config asserts it wins; one with no config asserts the loader returns `{}` rather than falling back to bundled). `Path.home()` is redirected via both `HOME` and `USERPROFILE` so Linux, macOS, and Windows are isolated uniformly (Windows-only Path.home() reads `USERPROFILE`, not `HOME`).
- [x] `pytest tests/test_cluster_dispatch_missing_backend.py` -- 4 existing tests still pass.
- [x] `ruff check` + `ruff format` clean.
- [x] Pre-commit hooks (ruff, ruff-format, pyright, large-files, project-team-on-main guard) all pass.
- [x] Local Linux full suite passes.
- [ ] CI green on PR run after the trigger-scope change takes effect.

Branched from `main` (not `develop`) so `.project_team/` audit-trail content stays out of the PR per the branch policy in `CLAUDE.md`.

Closes #50.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>