### PR TITLE
fix(app): right sidebar always visible on wide terminals

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -3147,16 +3147,16 @@ class ChatApp(App):
             pass
 
     def _layout_right_sidebar_inner(self) -> None:
-        # Show sidebar when wide enough and we have multiple agents, worktrees, or todos
-        agent_count = len(self.agent_mgr) if self.agent_mgr else 0
-        has_content = bool(
-            agent_count > 1
-            or self.agent_section._worktrees
-            or self.todo_panel.todos
-            or (self._review_panel and self._review_panel.review_count)
-            or self._workflow_engine
-            or self.files_section.item_count > 0
-        )
+        # Right sidebar is always reachable when the terminal has room: inline
+        # when wide enough, otherwise via the hamburger -> overlay path. The
+        # historical ``has_content`` gate (which hid the sidebar when there
+        # was only a single agent, no todos, no files, etc.) was removed
+        # because it also hid the ChicsessionLabel -- and a user on an empty
+        # session needs to see / interact with chicsession state to create
+        # one. Inner sections (FilesSection, PlanSection, ReviewPanel,
+        # ProcessPanel) still self-manage their own ``hidden`` class when
+        # empty, so the visible column never looks padded with empty
+        # headers.
         width = self.size.width
         main = self.query_one("#main", Horizontal)
 
@@ -3166,13 +3166,9 @@ class ChatApp(App):
         )
 
         # Compute desired state
-        show_sidebar_inline = width >= self.SIDEBAR_MIN_WIDTH and has_content
-        show_overlay = (
-            has_content and not show_sidebar_inline and self._sidebar_overlay_open
-        )
-        show_hamburger = (
-            has_content and not show_sidebar_inline and not self._sidebar_overlay_open
-        )
+        show_sidebar_inline = width >= self.SIDEBAR_MIN_WIDTH
+        show_overlay = not show_sidebar_inline and self._sidebar_overlay_open
+        show_hamburger = not show_sidebar_inline and not self._sidebar_overlay_open
         sidebar_shift = show_sidebar_inline and width < self.CENTERED_SIDEBAR_WIDTH
         hide_sidebar = not (show_sidebar_inline or show_overlay)
 
@@ -3185,8 +3181,9 @@ class ChatApp(App):
         )
         main.set_class(sidebar_shift, "sidebar-shift")
 
-        # Reset overlay state when not applicable
-        if not has_content or show_sidebar_inline:
+        # Reset overlay state when sidebar is shown inline (overlay is only
+        # meaningful on narrow terminals).
+        if show_sidebar_inline:
             self._sidebar_overlay_open = False
 
         # Layout sidebar contents when visible

--- a/tests/test_app_ui.py
+++ b/tests/test_app_ui.py
@@ -358,13 +358,48 @@ async def test_response_complete_enables_input(mock_sdk):
 
 
 @pytest.mark.asyncio
-async def test_sidebar_hidden_when_single_agent(mock_sdk):
-    """Right sidebar hidden with single agent and no todos."""
+async def test_sidebar_hidden_on_narrow_terminal(mock_sdk):
+    """Right sidebar hides on a narrow terminal (below SIDEBAR_MIN_WIDTH).
+
+    The hamburger then carries access to the sidebar via the overlay
+    path. Replaces the historical ``test_sidebar_hidden_when_single_agent``
+    which asserted that an empty session also hid the sidebar -- we
+    intentionally removed that ``has_content`` gate so ChicsessionLabel
+    stays reachable on an otherwise-empty session."""
     app = ChatApp()
+    # 100 cols is below SIDEBAR_MIN_WIDTH (110) -> sidebar collapses to
+    # the hamburger.
     async with app.run_test(size=(100, 40)):
         sidebar = app.query_one("#right-sidebar")
-        # With single agent and no todos, sidebar should be hidden
         assert sidebar.has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_sidebar_visible_on_wide_terminal_empty_session(mock_sdk):
+    """Right sidebar is visible on a wide terminal even with a single
+    agent, no todos, no files, no workflow, no worktrees, no reviews.
+
+    Regression for an empty-session usability hole: the sidebar used to
+    hide unless one of those content drivers was true, which made
+    ChicsessionLabel unreachable on a fresh session. The user needs to
+    see chicsession state (and the create-chicsession action it exposes)
+    even before there is any other content."""
+    app = ChatApp()
+    # 160 cols is well above SIDEBAR_MIN_WIDTH (110).
+    async with app.run_test(size=(160, 40)) as pilot:
+        await pilot.pause()
+        sidebar = app.query_one("#right-sidebar")
+        assert not sidebar.has_class("hidden"), (
+            "right sidebar must be visible on a wide terminal regardless of "
+            "content -- ChicsessionLabel needs to be reachable on empty sessions"
+        )
+        assert sidebar.display is True
+        # ChicsessionLabel rides inside the sidebar; if the column is
+        # visible, the label is queryable. Belt-and-suspenders.
+        from claudechic.widgets import ChicsessionLabel
+
+        label = app.query_one("#chicsession-label", ChicsessionLabel)
+        assert label.display is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_restore.py
+++ b/tests/test_workflow_restore.py
@@ -317,27 +317,28 @@ class TestRestoreSessionSidebarDisplay:
 class TestFilesSectionAfterRestore:
     """FilesSection must become visible after restore when uncommitted changes exist.
 
-    Root cause: _position_right_sidebar() evaluates has_content which does NOT include
-    files_section.item_count. So a single-agent session with no workflow and no worktrees
-    keeps the sidebar hidden even after _async_refresh_files populates FilesSection.
+    Originally written to drive a fix for a ``has_content``-based gate
+    that hid the sidebar on single-agent sessions even when files were
+    present. That gate has since been removed entirely (sidebar is now
+    visible whenever the terminal is wide enough), so the
+    "stays hidden" preconditions in these tests no longer hold. The
+    end-state assertions (FilesSection visible, sidebar visible after
+    files are added) still encode the correct contract and are kept.
 
-    Two coupled failures:
-    1. has_content ignores file changes -- _position_right_sidebar never shows sidebar
-       for single-agent sessions based on file changes alone.
-    2. _async_refresh_files never re-calls _position_right_sidebar after mounting files,
-       so even if has_content were fixed, the sidebar wouldn't re-evaluate.
+    Two coupled failures the original suite covered:
+    1. has_content ignores file changes -- fixed by removing the
+       has_content gate.
+    2. _async_refresh_files never re-calls _position_right_sidebar after
+       mounting files. Still relevant: FilesSection visibility flips
+       only after the layout pass, so _async_refresh_files must trigger
+       it.
     """
 
-    async def test_sidebar_stays_hidden_when_files_added_single_agent(
-        self, mock_sdk, tmp_path
-    ):
-        """With 1 agent, no workflow, and no worktrees, adding files to FilesSection
-        does not make the sidebar visible -- _position_right_sidebar ignores files.
-
-        This FAILS because has_content does not include files_section.item_count.
-        Fix: add `or self.files_section.item_count > 0` to has_content in
-        _position_right_sidebar.
-        """
+    async def test_sidebar_visible_with_files_single_agent(self, mock_sdk, tmp_path):
+        """Sidebar is visible after files are added to FilesSection on a
+        single-agent session. Originally proved the has_content gate was
+        wrong; the gate is now gone and sidebar is unconditionally
+        visible on a wide terminal, so the assertion is even stronger."""
         from pathlib import Path
         from unittest.mock import patch
 
@@ -355,13 +356,17 @@ class TestFilesSectionAfterRestore:
                     app.agent_section._worktrees.clear()
                     app._workflow_engine = None
 
-                    # Verify precondition: sidebar IS hidden (has_content = False)
+                    # Sidebar is now visible regardless of content (wide
+                    # terminal, no narrow-collapse). The previous version
+                    # of this test asserted ``hidden`` here as a
+                    # precondition; that precondition is intentionally
+                    # gone -- chicsession state must always be reachable.
                     app._position_right_sidebar()
                     await pilot.pause()
                     sidebar = app.query_one("#right-sidebar")
-                    assert sidebar.has_class("hidden"), (
-                        "Precondition: sidebar must be hidden with 1 agent, "
-                        "no workflow, no worktrees, no todos"
+                    assert not sidebar.has_class("hidden"), (
+                        "Sidebar must be visible on a wide terminal even "
+                        "before any files are added (chicsession reachability)"
                     )
 
                     # Simulate what _async_refresh_files does when it finds changed files
@@ -380,27 +385,26 @@ class TestFilesSectionAfterRestore:
                     app._position_right_sidebar()
                     await pilot.pause()
 
-                    # FAILS: sidebar is still hidden because has_content does not
-                    # include files_section.item_count. FilesSection is visible inside
-                    # a hidden sidebar -- the user sees nothing.
+                    # Sidebar must remain visible after files are added.
+                    # (Originally drove a fix for has_content ignoring
+                    # files; today's contract is "always visible when
+                    # wide", so this is the steady-state assertion.)
                     assert not sidebar.has_class("hidden"), (
-                        "Sidebar must be visible when FilesSection has file items. "
-                        "Bug: has_content in _position_right_sidebar ignores "
-                        "files_section.item_count. "
-                        "Fix: add `or self.files_section.item_count > 0` to has_content."
+                        "Sidebar must be visible when FilesSection has file items"
                     )
 
-    async def test_async_refresh_files_does_not_recheck_sidebar_visibility(
+    async def test_async_refresh_files_makes_files_section_visible(
         self, mock_sdk, tmp_path
     ):
-        """Even with has_content fixed, _async_refresh_files never calls
-        _position_right_sidebar() after mounting files -- sidebar stays hidden.
+        """``_async_refresh_files`` must mount files AND surface the
+        FilesSection (not just the outer sidebar -- the section
+        self-manages its own ``hidden`` class).
 
-        This FAILS because _async_refresh_files calls mount_all_files() but
-        does not call self._position_right_sidebar() afterward.
-        Fix: call self._position_right_sidebar() at end of _async_refresh_files
-        when stats are non-empty.
-        """
+        Historical context: this test previously asserted that the
+        outer sidebar was hidden as a precondition. With the
+        always-visible-when-wide contract that gate is gone; the test
+        now focuses on the inner FilesSection visibility flip, which
+        is still the meaningful contract for ``_async_refresh_files``."""
         from unittest.mock import AsyncMock, patch
 
         from claudechic.features.diff.git import FileStat
@@ -426,12 +430,19 @@ class TestFilesSectionAfterRestore:
                         app.agent_section._worktrees.clear()
                         app._workflow_engine = None
 
-                        # Verify precondition: sidebar is hidden
+                        # Sidebar starts visible on a wide terminal
+                        # (always-visible contract). Pre-_async_refresh
+                        # the FilesSection inner class is hidden because
+                        # no files have been mounted yet.
                         app._position_right_sidebar()
                         await pilot.pause()
                         sidebar = app.query_one("#right-sidebar")
-                        assert sidebar.has_class("hidden"), (
-                            "Precondition: sidebar must start hidden"
+                        files_section_pre = app.query_one(
+                            "#files-section", FilesSection
+                        )
+                        assert not sidebar.has_class("hidden")
+                        assert files_section_pre.has_class("hidden"), (
+                            "Precondition: FilesSection starts hidden before files mount"
                         )
 
                         # Run _async_refresh_files directly -- this is what
@@ -442,22 +453,18 @@ class TestFilesSectionAfterRestore:
                         await app._async_refresh_files(active)
                         await pilot.pause()
 
-                        # FilesSection now has items
+                        # FilesSection now has items and must be visible.
                         files_section = app.query_one("#files-section", FilesSection)
                         assert files_section.item_count == 2, (
                             f"Expected 2 file items, got {files_section.item_count}. "
                             "Check that get_file_stats is patched correctly."
                         )
-
-                        # FAILS: sidebar is still hidden.
-                        # _async_refresh_files mounts files but never calls
-                        # _position_right_sidebar() to re-evaluate sidebar visibility.
-                        assert not sidebar.has_class("hidden"), (
-                            "Sidebar must be visible after _async_refresh_files adds files. "
-                            "Bug: _async_refresh_files does not call _position_right_sidebar(). "
-                            "Fix: call self._position_right_sidebar() at the end of "
-                            "_async_refresh_files when stats are non-empty."
+                        assert not files_section.has_class("hidden"), (
+                            "FilesSection must un-hide after _async_refresh_files mounts files"
                         )
+                        # Outer sidebar remains visible too (it never
+                        # hid in the first place under the new contract).
+                        assert not sidebar.has_class("hidden")
 
     async def test_real_git_repo_files_section_becomes_visible(
         self, mock_sdk, tmp_path, monkeypatch
@@ -524,14 +531,22 @@ class TestFilesSectionAfterRestore:
                         f"Agent cwd mismatch: expected {tmp_path}, got {active.cwd}"
                     )
 
-                    # Confirm sidebar starts hidden (single agent, no workflow)
+                    # Sidebar starts visible (always-visible-when-wide
+                    # contract); the meaningful precondition for this
+                    # test is that FilesSection has not yet mounted any
+                    # files, so its inner section is hidden.
                     sidebar = app.query_one("#right-sidebar")
                     app.agent_section._worktrees.clear()
                     app._workflow_engine = None
                     app._position_right_sidebar()
                     await pilot.pause()
-                    assert sidebar.has_class("hidden"), (
-                        "Precondition: sidebar must be hidden before files load"
+                    files_section_pre = app.query_one("#files-section", FilesSection)
+                    assert not sidebar.has_class("hidden"), (
+                        "Sidebar should be visible on a wide terminal regardless "
+                        "of content (chicsession reachability contract)"
+                    )
+                    assert files_section_pre.has_class("hidden"), (
+                        "Precondition: FilesSection must start hidden before files load"
                     )
 
                     # 4. Run file refresh -- this is what create_safe_task would schedule


### PR DESCRIPTION
## Why

I want the **chicsession info** and the **Workflows button** to always be reachable in the right sidebar -- even on a fresh session with one agent, no todos, no files, no workflow, no worktrees. Both live on the \`ChicsessionLabel\` widget at the top of the right column, and right now the column itself disappears whenever none of the historical content drivers (multiple agents, worktrees, todos, reviews, workflow, files) are present. That makes a brand-new session feel inert: there is no visible affordance to create or pick a chicsession or activate a workflow until something else has populated the sidebar first.

## What changed

\`_layout_right_sidebar_inner\` no longer gates visibility on \`has_content\`. The contract is now:

- **Wide terminal (>= SIDEBAR_MIN_WIDTH)**: right sidebar always shown inline.
- **Narrow terminal**: sidebar collapses to the hamburger button (also unconditional -- it used to require has_content too), which still opens the sidebar as an overlay.
- **Inner sections** (\`FilesSection\`, \`PlanSection\`, \`ReviewPanel\`, \`ProcessPanel\`) keep their own hidden-when-empty toggles. The column never looks padded with empty headers; only sections with content render. \`ChicsessionLabel\` and \`AgentSection\` were already always-on inside the column, so removing the outer gate is enough to surface them on empty sessions.

## Test plan

- [x] **New regression**: \`test_sidebar_visible_on_wide_terminal_empty_session\` -- launches the TUI on a 160-col terminal with one agent and zero other content, asserts both \`#right-sidebar\` and \`#chicsession-label\` are visible.
- [x] **Renamed**: \`test_sidebar_hidden_when_single_agent\` -> \`test_sidebar_hidden_on_narrow_terminal\` (still pins the narrow-collapse contract; the previous name was misleading because narrowness, not agent count, is what hides the sidebar today).
- [x] **Three updated tests** in \`TestFilesSectionAfterRestore\`: their "sidebar starts hidden" preconditions are flipped to "sidebar starts visible; FilesSection inner section starts hidden until files mount". The end-state contracts they originally drove (FilesSection visible after files load, sidebar visible after files load) are unchanged.
- [x] Full suite: 872 passed, 1 skipped, 2 xfailed.
- [x] \`ruff check\` + \`ruff format\` clean. Pyright clean.

## Out of scope

This PR does not change \`FilesSection\`'s own hide-when-empty behavior, the hamburger styling, or any other sidebar layout logic. If we later want an empty-state placeholder inside \`FilesSection\` ("No changes") that's a separate change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>