### PR TITLE
feat(app): confirm before opening URLs in the system browser

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -3491,6 +3491,56 @@ class ChatApp(App):
         if handler:
             handler(event)
 
+    def on_markdown_link_clicked(self, event) -> None:
+        """Confirm before opening a clicked URL in the system browser.
+
+        All Markdown content in claudechic is rendered via SafeMarkdown
+        (open_links=False), so this event reaches us unhandled. We
+        prompt with URLConfirmModal; if the user confirms we run
+        webbrowser.open on a worker thread so the system-browser spawn
+        does not freeze the TUI event loop. See
+        widgets/content/safe_markdown.py for the underlying issue.
+
+        Why a confirm step at all: a single misclick on a URL in chat
+        output used to trigger a synchronous webbrowser.open that
+        blocked the TUI for several seconds (multiple seconds on WSL,
+        Linux without $DISPLAY, or remote SSH). The confirm modal
+        makes misclicks free (one keypress to dismiss) without
+        removing the convenience of intentional clicks.
+        """
+        from claudechic.widgets.modals.url_confirm import URLConfirmModal
+
+        event.stop()
+        url = getattr(event, "href", "") or ""
+        if not url:
+            return
+
+        def _on_dismiss(confirmed: bool | None) -> None:
+            if confirmed:
+                # Schedule the launch on the running loop so the modal
+                # fully tears down first (clean redraw) and the browser
+                # spawn never blocks the event loop.
+                asyncio.create_task(self._open_url_async(url))
+
+        self.push_screen(URLConfirmModal(url), _on_dismiss)
+
+    async def _open_url_async(self, url: str) -> None:
+        """Run webbrowser.open on a worker thread so spawning the OS
+        browser does not freeze the TUI.
+
+        ``webbrowser.open`` may take many seconds on Linux without
+        $DISPLAY, on WSL, or on remote SSH sessions; doing it inline
+        on the event loop is what produced the original "click a link
+        and the TUI hangs" bug.
+        """
+        import webbrowser
+
+        try:
+            await asyncio.to_thread(webbrowser.open, url)
+        except Exception as e:
+            log.warning("webbrowser.open failed for %s: %s", url, e)
+            self.notify(f"Could not open URL: {e}", severity="error")
+
     def on_mouse_up(self, event: MouseUp) -> None:
         # Close sidebar overlay if clicking outside of it
         if self._sidebar_overlay_open:

--- a/claudechic/widgets/content/__init__.py
+++ b/claudechic/widgets/content/__init__.py
@@ -11,6 +11,7 @@ from claudechic.widgets.content.message import (
     SystemInfo,
     ThinkingIndicator,
 )
+from claudechic.widgets.content.safe_markdown import SafeMarkdown
 from claudechic.widgets.content.todo import TodoItem, TodoPanel, TodoWidget
 from claudechic.widgets.content.tools import (
     AgentListWidget,
@@ -39,6 +40,7 @@ __all__ = [
     "PendingShellWidget",
     "EditPlanRequested",
     "DiffWidget",
+    "SafeMarkdown",
     "TodoWidget",
     "TodoPanel",
     "TodoItem",

--- a/claudechic/widgets/content/markdown_preview.py
+++ b/claudechic/widgets/content/markdown_preview.py
@@ -6,7 +6,12 @@ from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.message import Message
 from textual.screen import ModalScreen
-from textual.widgets import Markdown, Static
+from textual.widgets import Static
+
+from claudechic.widgets.content.safe_markdown import SafeMarkdown as Markdown
+
+# ``Markdown`` above is ``SafeMarkdown`` (no synchronous link-open
+# freeze). See widgets/content/safe_markdown.py for rationale.
 
 
 class PreviewToggle(Static):

--- a/claudechic/widgets/content/message.py
+++ b/claudechic/widgets/content/message.py
@@ -9,12 +9,21 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
-from textual.widgets import Markdown, Static, TextArea
+from textual.widgets import Static, TextArea
 
 from claudechic.errors import log_exception
+from claudechic.widgets.content.safe_markdown import SafeMarkdown as Markdown
 from claudechic.widgets.input.vi_mode import ViHandler, ViMode
 from claudechic.widgets.primitives.button import Button
 from claudechic.widgets.primitives.spinner import Spinner
+
+# Note: ``Markdown`` above is ``SafeMarkdown`` -- the bare
+# ``textual.widgets.Markdown`` opens links via a synchronous
+# ``webbrowser.open`` call that freezes the TUI for several seconds
+# while the OS spawns a browser. ``SafeMarkdown`` defaults
+# ``open_links=False`` and the LinkClicked event bubbles to
+# ``ChatApp.on_markdown_link_clicked`` for confirmation. Do NOT
+# revert this import or click freezes return.
 
 
 class MessageMetadataHeader(Static):

--- a/claudechic/widgets/content/safe_markdown.py
+++ b/claudechic/widgets/content/safe_markdown.py
@@ -1,0 +1,42 @@
+"""SafeMarkdown -- Markdown widget that does NOT auto-launch links.
+
+Textual's default ``Markdown`` widget has ``open_links=True`` and
+routes clicks through the app's URL-opening path, which ultimately
+calls ``webbrowser`` synchronously. While the OS spawns the browser
+process the entire TUI event loop is frozen. On WSL, Linux without
+``$DISPLAY`` set, or remote SSH sessions the freeze can be many
+seconds and there is no way to interrupt it -- escape, Ctrl+C, and
+the like never reach the TUI until the synchronous launch returns.
+
+``SafeMarkdown`` flips ``open_links`` off by default. The
+``Markdown.LinkClicked`` message still bubbles up the widget tree, so
+``ChatApp.on_markdown_link_clicked`` can intercept it, prompt the
+user via ``URLConfirmModal``, and -- on confirm -- launch the browser
+on a worker thread (no event-loop block).
+
+Use ``SafeMarkdown`` in place of ``Markdown`` everywhere we render
+content that may contain links: chat messages, tool output, plan
+panels, prompt previews, file previews. Importing the bare
+``textual.widgets.Markdown`` re-introduces the freeze; a comment in
+each call site reminds future contributors why.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.widgets import Markdown
+
+
+class SafeMarkdown(Markdown):
+    """Markdown subclass with ``open_links`` defaulted to ``False``.
+
+    Callers may still pass ``open_links=True`` explicitly if they want
+    the default Textual behavior (e.g. a future controlled-environment
+    use case where blocking is acceptable). The default-off posture is
+    what protects every existing call site.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("open_links", False)
+        super().__init__(*args, **kwargs)

--- a/claudechic/widgets/content/tools.py
+++ b/claudechic/widgets/content/tools.py
@@ -10,7 +10,7 @@ from claude_agent_sdk import ToolResultBlock, ToolUseBlock
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.message import Message
-from textual.widgets import Markdown, Static
+from textual.widgets import Static
 
 from claudechic.enums import ToolName
 from claudechic.formatting import (
@@ -23,6 +23,10 @@ from claudechic.formatting import (
 )
 from claudechic.widgets.base.tool_base import BaseToolWidget
 from claudechic.widgets.content.diff import DiffWidget
+from claudechic.widgets.content.safe_markdown import SafeMarkdown as Markdown
+
+# ``Markdown`` above is ``SafeMarkdown`` (no synchronous link-open
+# freeze). See widgets/content/safe_markdown.py for rationale.
 from claudechic.widgets.content.message import ChatMessage
 from claudechic.widgets.primitives.button import Button
 from claudechic.widgets.primitives.collapsible import QuietCollapsible

--- a/claudechic/widgets/modals/__init__.py
+++ b/claudechic/widgets/modals/__init__.py
@@ -5,6 +5,7 @@ from claudechic.widgets.modals.computer_info import ComputerInfoModal
 from claudechic.widgets.modals.process_detail import ProcessDetailModal
 from claudechic.widgets.modals.process_modal import ProcessModal
 from claudechic.widgets.modals.profile import ProfileModal
+from claudechic.widgets.modals.url_confirm import URLConfirmModal
 
 __all__ = [
     "ComputerInfoModal",
@@ -13,4 +14,5 @@ __all__ = [
     "ProfileModal",
     "ProcessModal",
     "ProcessDetailModal",
+    "URLConfirmModal",
 ]

--- a/claudechic/widgets/modals/url_confirm.py
+++ b/claudechic/widgets/modals/url_confirm.py
@@ -1,0 +1,88 @@
+"""URLConfirmModal -- ask before opening a URL in the system browser.
+
+Dismisses with ``True`` if the user confirms, ``False`` / ``None``
+otherwise. The caller (``ChatApp.on_markdown_link_clicked``) is
+responsible for actually launching the browser on confirm; this
+modal only collects intent.
+
+Why we need this: Textual's default Markdown link handler calls
+``webbrowser.open`` synchronously, which freezes the TUI for several
+seconds while the OS spawns a browser. A misclick on a link in chat
+output therefore costs visible UI time. ``URLConfirmModal`` makes
+misclicks free (cancel is one keypress) and intentional clicks
+async-launchable.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class URLConfirmModal(ModalScreen[bool | None]):
+    """Confirm prompt before opening a URL in the system browser.
+
+    Returns ``True`` on confirm, ``False`` on explicit decline, ``None``
+    if the modal is dismissed by other means (e.g. the screen stack
+    being torn down). Callers should treat anything that is not
+    ``True`` as "do nothing".
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss(False)", "Cancel"),
+        Binding("n", "dismiss(False)", "No"),
+        Binding("y", "confirm", "Yes"),
+        Binding("enter", "confirm", "Open"),
+    ]
+
+    DEFAULT_CSS = """
+    URLConfirmModal {
+        align: center middle;
+    }
+    URLConfirmModal #url-confirm-container {
+        width: 80%;
+        max-width: 80;
+        height: auto;
+        background: $surface;
+        border: round $primary;
+        padding: 1 2;
+    }
+    URLConfirmModal .url-confirm-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    URLConfirmModal .url-confirm-url {
+        color: $accent;
+        margin-bottom: 1;
+    }
+    URLConfirmModal .url-confirm-help {
+        color: $text-muted;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, url: str) -> None:
+        super().__init__()
+        self._url = url
+
+    @property
+    def url(self) -> str:
+        """Expose the URL for tests and external introspection."""
+        return self._url
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="url-confirm-container"):
+            yield Static("Open URL in browser?", classes="url-confirm-title")
+            # Render the URL as plain text -- no markup interpretation, so
+            # square brackets in the URL cannot mis-render as Rich tags.
+            yield Static(self._url, classes="url-confirm-url", markup=False)
+            yield Static(
+                "[y / enter] Open    [n / esc] Cancel",
+                classes="url-confirm-help",
+            )
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)

--- a/tests/test_url_click_confirm.py
+++ b/tests/test_url_click_confirm.py
@@ -1,0 +1,234 @@
+"""Tests for the URL-click confirmation flow.
+
+Originally driven by the user complaint "is there a way to cancel the
+in-app web browser, if I click a link by mistake it is very annoying
+to wait and exit." There is no in-app browser -- the freeze is
+Textual's default ``Markdown`` widget calling ``webbrowser.open``
+synchronously on the event loop. The fix has three pieces, each
+covered here:
+
+1. ``SafeMarkdown`` defaults ``open_links=False`` so the ``Markdown``
+   widget does not auto-launch the browser. The LinkClicked event
+   bubbles up to the app instead.
+2. ``ChatApp.on_markdown_link_clicked`` shows ``URLConfirmModal`` and
+   only opens the URL on confirm.
+3. The actual ``webbrowser.open`` call runs on a worker thread via
+   ``asyncio.to_thread`` so even on confirm the event loop is never
+   blocked.
+
+The tests assert each piece in isolation plus an end-to-end flow that
+mounts a real ``SafeMarkdown``, simulates a link click, and verifies
+the modal shows / browser opens / cancel is honored.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from claudechic.app import ChatApp
+from claudechic.widgets.content.safe_markdown import SafeMarkdown
+from claudechic.widgets.modals.url_confirm import URLConfirmModal
+
+
+# ---------------------------------------------------------------------------
+# Unit: SafeMarkdown
+# ---------------------------------------------------------------------------
+
+
+def test_safe_markdown_defaults_open_links_false() -> None:
+    """Without an explicit override, SafeMarkdown turns off Textual's
+    auto-open behavior. This is the keystone of the fix -- if a future
+    refactor flips the default, the synchronous-freeze bug returns."""
+    widget = SafeMarkdown("# hi")
+    assert widget._open_links is False, (
+        "SafeMarkdown must default open_links=False so link clicks "
+        "bubble to ChatApp.on_markdown_link_clicked instead of going "
+        "through the synchronous webbrowser.open path"
+    )
+
+
+def test_safe_markdown_respects_explicit_open_links() -> None:
+    """Callers may still opt into the default Textual behavior. The
+    safety property is the *default*, not a hard prohibition."""
+    widget = SafeMarkdown("# hi", open_links=True)
+    assert widget._open_links is True
+
+
+# ---------------------------------------------------------------------------
+# Unit: URLConfirmModal
+# ---------------------------------------------------------------------------
+
+
+def test_url_confirm_modal_exposes_url() -> None:
+    """Sanity that the URL we pass in is what the modal reports back.
+    Tests further down inspect ``modal.url`` to assert that the right
+    URL was offered to the user."""
+    modal = URLConfirmModal("https://example.com/very/long/path?q=1")
+    assert modal.url == "https://example.com/very/long/path?q=1"
+
+
+# ---------------------------------------------------------------------------
+# Integration: ChatApp.on_markdown_link_clicked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_link_click_pushes_confirm_modal(mock_sdk) -> None:
+    """A markdown link click pushes URLConfirmModal carrying the URL
+    -- it does NOT call webbrowser.open. This is the core
+    misclick-protection contract."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        with patch("webbrowser.open") as mock_open:
+            # Simulate the link-click event by invoking the handler
+            # directly with a stub event object that carries .href.
+            # Using the real handler path means a future refactor that
+            # renames the attribute or skips event.stop() will be caught.
+            event = MagicMock()
+            event.href = "https://example.com/clicked"
+            app.on_markdown_link_clicked(event)
+            await pilot.pause()
+
+            # Modal is now on top of the screen stack.
+            top = app.screen
+            assert isinstance(top, URLConfirmModal), (
+                f"Expected URLConfirmModal on top of stack, got {type(top).__name__}"
+            )
+            assert top.url == "https://example.com/clicked"
+
+            # Crucially, no browser was launched yet -- the user has not
+            # confirmed. This is the misclick protection.
+            mock_open.assert_not_called()
+
+            # event.stop must have been called so the click does not
+            # leak to other handlers (no double-modal).
+            event.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_confirm_modal_yes_opens_url_on_thread(mock_sdk) -> None:
+    """Pressing 'y' in the confirm modal launches webbrowser.open --
+    AND it goes through asyncio.to_thread so the event loop is not
+    blocked. The to_thread routing is the half of the fix that prevents
+    the original freeze even on intentional clicks."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        with (
+            patch("webbrowser.open") as mock_open,
+            patch(
+                "asyncio.to_thread",
+                wraps=__import__("asyncio").to_thread,
+            ) as spy_to_thread,
+        ):
+            event = MagicMock()
+            event.href = "https://example.com/intentional"
+            app.on_markdown_link_clicked(event)
+            await pilot.pause()
+            assert isinstance(app.screen, URLConfirmModal)
+
+            # Press 'y' to confirm.
+            await pilot.press("y")
+            await pilot.pause()
+            # Allow the scheduled to_thread to run.
+            await pilot.pause()
+
+            # webbrowser.open got the right URL.
+            mock_open.assert_called_once_with("https://example.com/intentional")
+            # And it went via to_thread (not inline on the loop). Look
+            # for the call whose first positional arg is webbrowser.open.
+            assert any(
+                call.args and call.args[0] is __import__("webbrowser").open
+                for call in spy_to_thread.call_args_list
+            ), (
+                "webbrowser.open must be dispatched through asyncio.to_thread "
+                "to keep the OS browser-spawn off the event loop"
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_confirm_modal_escape_cancels_no_open(mock_sdk) -> None:
+    """Pressing escape (or 'n') dismisses the modal without launching
+    the browser. This is the misclick path -- the whole point of the
+    feature."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        with patch("webbrowser.open") as mock_open:
+            event = MagicMock()
+            event.href = "https://example.com/misclick"
+            app.on_markdown_link_clicked(event)
+            await pilot.pause()
+            assert isinstance(app.screen, URLConfirmModal)
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Modal is gone, browser was not launched.
+            assert not isinstance(app.screen, URLConfirmModal)
+            mock_open.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_link_click_with_empty_href_is_ignored(mock_sdk) -> None:
+    """A pathological event with no href -- shouldn't crash and
+    shouldn't pop a modal with an empty URL."""
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        event = MagicMock()
+        event.href = ""
+        app.on_markdown_link_clicked(event)
+        await pilot.pause()
+
+        assert not isinstance(app.screen, URLConfirmModal), (
+            "Empty href should not pop the confirm modal"
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: SafeMarkdown -> bubbled event -> ChatApp handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_e2e_safe_markdown_click_routes_through_app_handler(mock_sdk) -> None:
+    """Mounts a real SafeMarkdown widget, posts a Markdown.LinkClicked
+    message from it, and verifies the app's confirm flow fires. This
+    catches a regression where SafeMarkdown stops bubbling the event
+    or where ChatApp's handler signature changes shape."""
+    from textual.widgets import Markdown as TextualMarkdown
+
+    app = ChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        # Mount a SafeMarkdown into the active screen so the
+        # LinkClicked message has a real bubble path to the app.
+        md = SafeMarkdown("[click me](https://example.com/e2e)")
+        await app.screen.mount(md)
+        await pilot.pause()
+
+        with patch("webbrowser.open") as mock_open:
+            md.post_message(TextualMarkdown.LinkClicked(md, "https://example.com/e2e"))
+            await pilot.pause()
+
+            # Confirm modal arrived from the bubbled event.
+            assert isinstance(app.screen, URLConfirmModal)
+            assert app.screen.url == "https://example.com/e2e"
+
+            # Misclick path: dismiss.
+            await pilot.press("escape")
+            await pilot.pause()
+            mock_open.assert_not_called()


### PR DESCRIPTION
## Why

Reported by user: clicking a markdown link in chat (intentional or accidental) freezes the TUI for several seconds with no way to cancel. Diagnosed as Textual's default \`Markdown\` widget calling \`webbrowser.open\` **synchronously on the event loop** -- the freeze is the OS spawning the browser process. Escape, Ctrl+C, etc. don't reach the TUI until the spawn returns. Worst on WSL, Linux without \`\$DISPLAY\`, and remote SSH, where the spawn can take many seconds.

## What changes

Three pieces, each addressing a different layer:

1. **\`SafeMarkdown\`** (new) -- subclass of \`textual.widgets.Markdown\` with \`open_links=False\` default. Replaces bare \`Markdown\` at every render site:
   - \`widgets/content/message.py\` (4 sites)
   - \`widgets/content/tools.py\` (5 sites)
   - \`widgets/content/markdown_preview.py\` (1 site)
   Each import carries a comment explaining why \`textual.widgets.Markdown\` directly is the freeze re-entry point.

2. **\`URLConfirmModal\`** (new) -- \`ModalScreen[bool | None]\` that displays the URL and asks **Open?** \`[y / enter]\` / **Cancel** \`[n / esc]\`. Misclicks dismiss in one keypress.

3. **\`ChatApp.on_markdown_link_clicked\`** (new) -- intercepts the bubbled \`LinkClicked\` event, pushes the modal, and on confirm runs \`webbrowser.open\` via \`asyncio.to_thread\` so even intentional clicks **never** freeze the loop. The async dispatch means the original freeze is gone whether the user confirms or cancels.

## Test plan

8 new tests in \`tests/test_url_click_confirm.py\`:

- [x] \`SafeMarkdown\` defaults \`open_links=False\` (the keystone -- if a future refactor flips the default, the freeze returns).
- [x] \`SafeMarkdown\` honors explicit \`open_links=True\` (safety is the *default*, not a hard prohibition).
- [x] \`URLConfirmModal\` exposes the URL it carries.
- [x] Link click pushes the modal, does **not** call \`webbrowser.open\` (misclick protection).
- [x] Confirm (\`y\`) routes \`webbrowser.open\` through \`asyncio.to_thread\` -- explicitly asserts the to_thread spy was called with \`webbrowser.open\` so the no-freeze contract is pinned.
- [x] Escape dismisses without launching the browser.
- [x] Empty href is ignored gracefully.
- [x] End-to-end: real \`SafeMarkdown\` mount, posted \`LinkClicked\`, modal arrives via the bubble path.
- [x] Full suite 886 passed (one parallel-load flake unrelated to this change passed serially).
- [x] \`ruff check\` + \`ruff format\` clean. Pyright clean. Static encoding lint clean (had to rephrase a docstring that contained the literal token \`webbrowser.open(url)\` because the lint regex matches \`open(\` calls anywhere in source).

## Behavior summary

| Before | After |
|---|---|
| Click link -> TUI freezes for seconds while OS spawns browser. No exit. | Click link -> modal asks "Open URL?" -> y/enter opens via background thread (no freeze), n/esc dismisses (no browser launched). |

## Out of scope

- No change to URL detection in plain-text output. Only Markdown-rendered links are affected; bare URLs in tool output remain copy-paste only (which is fine, and is what most modern terminals also do).
- No new keybinding to "always allow" / remember choice -- if useful later, can add a checkbox to the modal.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>