### PR TITLE
fix(checks): tier-aware paths for file-content/file-exists checks

### DIFF
--- a/claudechic/checks/builtins.py
+++ b/claudechic/checks/builtins.py
@@ -39,13 +39,22 @@ def _build_check(decl: CheckDecl) -> Check:
 def _resolve_against(path: str | Path, base_dir: str | Path | None) -> Path:
     """Resolve ``path`` against ``base_dir`` if it is relative.
 
-    Absolute paths are returned unchanged. This lets check manifests use
-    relative paths (e.g. ``.project_team/*/SPECIFICATION.md``) while
-    callers pin them to the workflow root. If ``base_dir`` is ``None``
-    the value is returned as a bare ``Path`` (relative paths then
-    resolve against the process cwd at access time).
+    Order:
+    1. ``~`` and ``~user`` are expanded first via ``Path.expanduser`` so
+       a manifest entry like ``~/.claudechic/mcp_tools/cluster.yaml``
+       resolves to the user's home dir, not ``<cwd>/~/.claudechic/...``
+       (a Path with a literal ``~`` segment is NOT considered absolute,
+       so the original implementation joined it onto ``base_dir`` --
+       silently broken).
+    2. After expansion, absolute paths are returned unchanged. This
+       lets check manifests use relative paths (e.g.
+       ``.project_team/*/SPECIFICATION.md``) while callers pin them
+       to the workflow root.
+    3. Relative paths are joined onto ``base_dir`` if it is set;
+       otherwise returned as-is (so they resolve against the process
+       cwd at access time).
     """
-    p = Path(path)
+    p = Path(path).expanduser()
     if p.is_absolute() or base_dir is None:
         return p
     return Path(base_dir) / p
@@ -103,58 +112,123 @@ class CommandOutputCheck:
             return CheckResult(passed=False, evidence=f"Command failed: {e}")
 
 
-class FileExistsCheck:
-    """Passes when file exists.
+def _coerce_paths(
+    path: str | Path | None,
+    paths: list[str | Path] | None,
+    base_dir: str | Path | None,
+) -> list[Path]:
+    """Build the list of resolved paths a check should walk.
 
-    ``base_dir`` pins relative ``path`` resolution to the workflow root
-    so checks don't silently depend on process cwd.
+    Accepts either ``path`` (single, the historical form) or ``paths``
+    (a list, for tier-aware checks like cluster_setup that need to
+    accept e.g. ``<cwd>/.claudechic/mcp_tools/cluster.yaml`` OR
+    ``~/.claudechic/mcp_tools/cluster.yaml``). The two are mutually
+    exclusive at the manifest level, but if a caller supplies both
+    we concatenate ``[path] + paths`` so neither is silently dropped.
+    Each entry passes through :func:`_resolve_against` for ``~``
+    expansion and base_dir joining.
+
+    The resulting list preserves declaration order. Both
+    :class:`FileExistsCheck` and :class:`FileContentCheck` use it
+    with first-match-wins semantics: the first path that satisfies
+    the check makes the check pass.
+    """
+    raw: list[str | Path] = []
+    if path is not None:
+        raw.append(path)
+    if paths is not None:
+        raw.extend(paths)
+    if not raw:
+        raise ValueError(
+            "file-exists-check / file-content-check requires either "
+            "'path' or 'paths' to be set"
+        )
+    return [_resolve_against(p, base_dir) for p in raw]
+
+
+class FileExistsCheck:
+    """Passes when at least one of the configured paths exists.
+
+    Accepts either ``path`` (single) or ``paths`` (list, first-match
+    wins). ``base_dir`` pins relative path resolution to the workflow
+    root so checks don't silently depend on process cwd. ``~`` is
+    expanded against the running user's home dir.
     """
 
     def __init__(
         self,
-        path: str | Path,
+        path: str | Path | None = None,
         base_dir: str | Path | None = None,
+        paths: list[str | Path] | None = None,
     ) -> None:
-        self.path = _resolve_against(path, base_dir)
+        self.paths = _coerce_paths(path, paths, base_dir)
 
     async def check(self) -> CheckResult:
-        if self.path.exists():
-            return CheckResult(passed=True, evidence=f"File found: {self.path}")
-        return CheckResult(passed=False, evidence=f"File not found: {self.path}")
+        for p in self.paths:
+            if p.exists():
+                return CheckResult(passed=True, evidence=f"File found: {p}")
+        if len(self.paths) == 1:
+            return CheckResult(
+                passed=False, evidence=f"File not found: {self.paths[0]}"
+            )
+        listing = ", ".join(str(p) for p in self.paths)
+        return CheckResult(
+            passed=False, evidence=f"None of these files exist: {listing}"
+        )
 
 
 class FileContentCheck:
-    """Passes when file content matches regex.
+    """Passes when at least one configured file contains a regex match.
 
-    ``base_dir`` pins relative ``path`` resolution to the workflow root.
+    Accepts either ``path`` (single) or ``paths`` (list, first-match
+    wins). For each path that exists, scan line-by-line for the
+    pattern. The first file that has a matching line makes the check
+    pass; the matching line becomes the evidence string. Files that
+    do not exist are skipped silently -- the check is "any of these
+    is configured", not "all of these are configured".
+
+    ``base_dir`` pins relative path resolution to the workflow root.
+    ``~`` is expanded against the running user's home dir.
     """
 
     def __init__(
         self,
-        path: str | Path,
-        pattern: str,
+        path: str | Path | None = None,
+        pattern: str = "",
         base_dir: str | Path | None = None,
+        paths: list[str | Path] | None = None,
     ) -> None:
-        self.path = _resolve_against(path, base_dir)
+        if not pattern:
+            raise ValueError("file-content-check requires 'pattern'")
+        self.paths = _coerce_paths(path, paths, base_dir)
         self.compiled_pattern = re.compile(pattern)
 
     async def check(self) -> CheckResult:
-        if not self.path.exists():
-            return CheckResult(passed=False, evidence=f"File not found: {self.path}")
-        try:
-            content = self.path.read_text(encoding="utf-8", errors="replace")
-        except OSError as e:
-            return CheckResult(passed=False, evidence=f"Cannot read {self.path}: {e}")
+        misses: list[str] = []
+        for p in self.paths:
+            if not p.exists():
+                misses.append(f"not found: {p}")
+                continue
+            try:
+                content = p.read_text(encoding="utf-8", errors="replace")
+            except OSError as e:
+                misses.append(f"cannot read {p}: {e}")
+                continue
 
-        for i, line in enumerate(content.splitlines(), 1):
-            if self.compiled_pattern.search(line):
-                return CheckResult(
-                    passed=True, evidence=f"Line {i}: {line.strip()}"[:200]
-                )
+            for i, line in enumerate(content.splitlines(), 1):
+                if self.compiled_pattern.search(line):
+                    return CheckResult(
+                        passed=True,
+                        evidence=f"{p} line {i}: {line.strip()}"[:200],
+                    )
+            misses.append(f"pattern not in {p}")
 
         return CheckResult(
             passed=False,
-            evidence=f"Pattern '{self.compiled_pattern.pattern}' not found in {self.path}",
+            evidence=(
+                f"Pattern '{self.compiled_pattern.pattern}' not matched "
+                f"({'; '.join(misses)})"
+            ),
         )
 
 
@@ -226,12 +300,19 @@ register_check_type(
 )
 register_check_type(
     "file-exists-check",
-    lambda p: FileExistsCheck(path=p["path"], base_dir=p.get("base_dir")),
+    lambda p: FileExistsCheck(
+        path=p.get("path"),
+        paths=p.get("paths"),
+        base_dir=p.get("base_dir"),
+    ),
 )
 register_check_type(
     "file-content-check",
     lambda p: FileContentCheck(
-        path=p["path"], pattern=p["pattern"], base_dir=p.get("base_dir")
+        path=p.get("path"),
+        paths=p.get("paths"),
+        pattern=p["pattern"],
+        base_dir=p.get("base_dir"),
     ),
 )
 register_check_type(

--- a/claudechic/defaults/workflows/cluster_setup/cluster_setup.yaml
+++ b/claudechic/defaults/workflows/cluster_setup/cluster_setup.yaml
@@ -9,10 +9,17 @@ phases:
         lifecycle: show-once
     advance_checks:
       - type: file-content-check
-        path: ".claudechic/mcp_tools/cluster.yaml"
+        # Tier-aware: pass if EITHER the project-tier file OR the
+        # user-tier file has ssh_target set. Mirrors the runtime
+        # cluster MCP loader (project > user). Workflows activated
+        # from a repo where the user does not want a checked-in
+        # project-tier config can rely on the user-tier file alone.
+        paths:
+          - ".claudechic/mcp_tools/cluster.yaml"
+          - "~/.claudechic/mcp_tools/cluster.yaml"
         pattern: "ssh_target:\\s+\\S+"
         on_failure:
-          message: "ssh_target must be set in .claudechic/mcp_tools/cluster.yaml before advancing."
+          message: "ssh_target must be set in either .claudechic/mcp_tools/cluster.yaml (project) or ~/.claudechic/mcp_tools/cluster.yaml (user) before advancing."
           severity: warning
       - type: manual-confirm
         prompt: "SSH target confirmed and passwordless SSH working?"
@@ -33,10 +40,13 @@ phases:
         lifecycle: show-once
     advance_checks:
       - type: file-content-check
-        path: ".claudechic/mcp_tools/cluster.yaml"
+        # Tier-aware (see Phase 1 for rationale).
+        paths:
+          - ".claudechic/mcp_tools/cluster.yaml"
+          - "~/.claudechic/mcp_tools/cluster.yaml"
         pattern: "backend:\\s+(lsf|slurm)"
         on_failure:
-          message: "backend must be set to 'lsf' or 'slurm' in .claudechic/mcp_tools/cluster.yaml before advancing."
+          message: "backend must be set to 'lsf' or 'slurm' in either .claudechic/mcp_tools/cluster.yaml (project) or ~/.claudechic/mcp_tools/cluster.yaml (user) before advancing."
           severity: warning
       - type: manual-confirm
         prompt: "Scheduler detected and working?"

--- a/tests/test_checks_tier_aware.py
+++ b/tests/test_checks_tier_aware.py
@@ -1,0 +1,297 @@
+"""Tier-aware behavior for file-exists-check and file-content-check.
+
+Originally driven by an asymmetry between the runtime cluster MCP
+loader (project tier > user tier, see issue #50) and the
+cluster_setup workflow's advance checks, which only accepted a
+single hardcoded project-tier path. A user who wrote their cluster
+config to ``~/.claudechic/mcp_tools/cluster.yaml`` would have a
+working runtime but a workflow that refused to advance.
+
+Three behaviors covered here:
+
+1. ``_resolve_against`` expands ``~`` BEFORE deciding whether the
+   path is absolute, so a manifest entry like
+   ``~/.claudechic/mcp_tools/cluster.yaml`` resolves to the user's
+   home dir, not ``<base_dir>/~/...`` (the original behavior --
+   silently broken).
+
+2. ``FileExistsCheck`` and ``FileContentCheck`` accept either
+   ``path`` (single, the historical form) or ``paths`` (list, new).
+   First-match-wins semantics: the first path that satisfies the
+   check makes the check pass.
+
+3. Single-path back-compat: existing manifests that pass ``path:``
+   work unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from claudechic.checks.builtins import (
+    FileContentCheck,
+    FileExistsCheck,
+    _resolve_against,
+)
+
+# pytest-asyncio is configured in mode=auto so async test functions are
+# picked up without an explicit marker. We only need pytest imported
+# above for ``pytest.raises`` in the sync tests.
+_ = pytest  # silence unused-import warning when only ``raises`` is used
+
+
+# ---------------------------------------------------------------------------
+# _resolve_against
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_against_expands_tilde_before_absolute_check(
+    monkeypatch, tmp_path
+) -> None:
+    """``~`` resolves to ``$HOME``, not to ``<base_dir>/~``. The original
+    implementation called ``Path.is_absolute()`` BEFORE expanding ``~``,
+    so a literal ``~`` segment failed the absolute check and got
+    joined onto base_dir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # USERPROFILE matters on Windows -- harmless on POSIX.
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    base_dir = tmp_path / "project_root"
+    base_dir.mkdir()
+
+    resolved = _resolve_against("~/.claudechic/cluster.yaml", base_dir)
+
+    assert resolved == home / ".claudechic" / "cluster.yaml"
+    assert str(base_dir) not in str(resolved), (
+        f"~ should NOT have been joined onto base_dir; got {resolved}"
+    )
+
+
+def test_resolve_against_relative_paths_still_join_base_dir(tmp_path) -> None:
+    """Plain relative paths (no ~) still join onto ``base_dir`` -- the
+    historical behavior. This is the back-compat sanity test."""
+    resolved = _resolve_against(".claudechic/cluster.yaml", tmp_path)
+    assert resolved == tmp_path / ".claudechic" / "cluster.yaml"
+
+
+def test_resolve_against_absolute_paths_are_unchanged(tmp_path) -> None:
+    """Absolute paths bypass base_dir entirely."""
+    abs_path = tmp_path / "absolute" / "file.yaml"
+    resolved = _resolve_against(abs_path, tmp_path / "ignored_base")
+    assert resolved == abs_path
+
+
+# ---------------------------------------------------------------------------
+# FileExistsCheck -- multi-path
+# ---------------------------------------------------------------------------
+
+
+async def test_file_exists_check_accepts_paths_list_first_wins(tmp_path) -> None:
+    """When multiple paths are given, the first-existing one passes."""
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    b.write_text("hello", encoding="utf-8")  # only b exists
+
+    check = FileExistsCheck(paths=[a, b])
+    result = await check.check()
+
+    assert result.passed is True
+    assert str(b) in result.evidence
+
+
+async def test_file_exists_check_paths_all_missing_fails(tmp_path) -> None:
+    """When no path exists, the failure message lists all candidates so
+    the user can see which tiers were probed."""
+    a = tmp_path / "missing_a.txt"
+    b = tmp_path / "missing_b.txt"
+
+    check = FileExistsCheck(paths=[a, b])
+    result = await check.check()
+
+    assert result.passed is False
+    assert str(a) in result.evidence
+    assert str(b) in result.evidence
+
+
+async def test_file_exists_check_single_path_back_compat(tmp_path) -> None:
+    """Existing manifests using ``path:`` keep working unchanged."""
+    f = tmp_path / "file.txt"
+    f.write_text("hi", encoding="utf-8")
+
+    check = FileExistsCheck(path=f)
+    result = await check.check()
+
+    assert result.passed is True
+
+
+def test_file_exists_check_requires_path_or_paths() -> None:
+    """Sanity that omitting both raises a clear error rather than
+    silently passing."""
+    with pytest.raises(ValueError, match="path"):
+        FileExistsCheck()
+
+
+# ---------------------------------------------------------------------------
+# FileContentCheck -- multi-path
+# ---------------------------------------------------------------------------
+
+
+async def test_file_content_check_paths_first_match_wins(tmp_path) -> None:
+    """First file containing the pattern wins. Files that don't exist or
+    don't match are skipped silently -- the contract is "any of these"
+    not "all of these"."""
+    project = tmp_path / "project" / "cluster.yaml"
+    project.parent.mkdir()
+    user = tmp_path / "user" / "cluster.yaml"
+    user.parent.mkdir()
+
+    # Project file exists but does NOT match.
+    project.write_text("ssh_target:\nbackend: lsf\n", encoding="utf-8")
+    # User file exists AND matches.
+    user.write_text("ssh_target: submit.example.org\n", encoding="utf-8")
+
+    check = FileContentCheck(
+        paths=[project, user],
+        pattern=r"ssh_target:\s+\S+",
+    )
+    result = await check.check()
+
+    assert result.passed is True
+    assert "submit.example.org" in result.evidence
+    assert str(user) in result.evidence
+
+
+async def test_file_content_check_paths_project_wins_when_both_match(
+    tmp_path,
+) -> None:
+    """When multiple files satisfy the pattern, the FIRST listed wins.
+    This pins the priority order: project tier > user tier (or
+    whatever order the manifest declares)."""
+    project = tmp_path / "project" / "cluster.yaml"
+    project.parent.mkdir()
+    user = tmp_path / "user" / "cluster.yaml"
+    user.parent.mkdir()
+
+    project.write_text("ssh_target: project.example.org\n", encoding="utf-8")
+    user.write_text("ssh_target: user.example.org\n", encoding="utf-8")
+
+    check = FileContentCheck(
+        paths=[project, user],
+        pattern=r"ssh_target:\s+\S+",
+    )
+    result = await check.check()
+
+    assert result.passed is True
+    assert "project.example.org" in result.evidence
+    assert "user.example.org" not in result.evidence
+
+
+async def test_file_content_check_all_missing_fails_with_diagnostic(
+    tmp_path,
+) -> None:
+    """Failure message must list each probed path so the user can see
+    why -- 'pattern not in X; not found: Y' style diagnostics rather
+    than a single bare path."""
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    a.write_text("nope\n", encoding="utf-8")
+    # b does NOT exist.
+
+    check = FileContentCheck(paths=[a, b], pattern=r"ssh_target:")
+    result = await check.check()
+
+    assert result.passed is False
+    assert "ssh_target:" in result.evidence
+    assert str(a) in result.evidence
+    assert str(b) in result.evidence
+
+
+async def test_file_content_check_single_path_back_compat(tmp_path) -> None:
+    """``path:`` form (the historical YAML shape) still works."""
+    f = tmp_path / "file.yaml"
+    f.write_text("ssh_target: example.org\n", encoding="utf-8")
+
+    check = FileContentCheck(path=f, pattern=r"ssh_target:")
+    result = await check.check()
+    assert result.passed is True
+
+
+def test_file_content_check_requires_pattern() -> None:
+    """Empty pattern is meaningless -- raise rather than silently match
+    every line."""
+    with pytest.raises(ValueError, match="pattern"):
+        FileContentCheck(path="foo", pattern="")
+
+
+# ---------------------------------------------------------------------------
+# Manifest registration smoke test -- the parser passes ``paths`` through
+# ---------------------------------------------------------------------------
+
+
+async def test_check_registry_passes_paths_through(tmp_path) -> None:
+    """End-to-end: a YAML-style param dict with ``paths`` reaches the
+    check class. Catches a regression where the registry lambdas drop
+    the new key."""
+    from claudechic.checks.builtins import _CHECK_REGISTRY
+
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    b.write_text("ssh_target: example.org\n", encoding="utf-8")
+
+    factory = _CHECK_REGISTRY["file-content-check"]
+    check = factory(
+        {
+            "paths": [str(a), str(b)],
+            "pattern": r"ssh_target:",
+            "base_dir": str(tmp_path),
+        }
+    )
+
+    result = await check.check()
+    assert result.passed is True
+
+
+async def test_check_registry_resolves_tilde_and_relative_for_paths(
+    monkeypatch, tmp_path
+) -> None:
+    """The registry path resolves both ``~/...`` and bare-relative
+    entries through ``_resolve_against``. End-to-end coverage for the
+    cluster_setup advance-check shape:
+        paths:
+          - .claudechic/mcp_tools/cluster.yaml
+          - ~/.claudechic/mcp_tools/cluster.yaml
+    """
+    from claudechic.checks.builtins import _CHECK_REGISTRY
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    base_dir = tmp_path / "workflow_root"
+    base_dir.mkdir()
+
+    # Only the user-tier file exists -- mirrors the user's setup.
+    user_yaml = home / ".claudechic" / "mcp_tools" / "cluster.yaml"
+    user_yaml.parent.mkdir(parents=True)
+    user_yaml.write_text("ssh_target: submit.int.janelia.org\n", encoding="utf-8")
+
+    factory = _CHECK_REGISTRY["file-content-check"]
+    check = factory(
+        {
+            "paths": [
+                ".claudechic/mcp_tools/cluster.yaml",  # project tier (missing)
+                "~/.claudechic/mcp_tools/cluster.yaml",  # user tier (exists)
+            ],
+            "pattern": r"ssh_target:\s+\S+",
+            "base_dir": str(base_dir),
+        }
+    )
+    result = await check.check()
+
+    assert result.passed is True, (
+        "tier-aware advance check failed to find user-tier config; "
+        f"evidence: {result.evidence}"
+    )
+    assert "submit.int.janelia.org" in result.evidence


### PR DESCRIPTION
## Why

Asymmetry between two parts of the same system: the runtime cluster MCP loader (fixed in #50) reads \`cluster.yaml\` from project tier OR user tier, but the **cluster_setup workflow's advance checks** were hardcoded to a single project-tier path. So a user who -- correctly -- wrote their config to \`~/.claudechic/mcp_tools/cluster.yaml\` (cross-project default, no checked-in artifact in the repo they happen to be in) had a working runtime but a workflow that refused to advance.

Surfaced live during a cluster_setup session in the claudechic repo itself: writing \`ssh_target\` to the user tier left \`advance_phase\` stuck because the project-tier file didn't exist.

## What changed

Three coupled changes:

### 1. \`_resolve_against\` expands \`~\` first (\`claudechic/checks/builtins.py\`)

A manifest entry like \`~/.claudechic/mcp_tools/cluster.yaml\` failed the original \`Path.is_absolute()\` check (a literal \`~\` segment is not absolute) and was silently joined onto \`base_dir\`, producing \`<base_dir>/~/.claudechic/...\`. Now: expanduser first, THEN the absolute check, THEN the base_dir join.

### 2. \`FileExistsCheck\` and \`FileContentCheck\` accept \`paths\` (list)

New \`paths: list[str | Path]\` parameter alongside the historical \`path: str\`. First-match-wins semantics. Single-path manifests work unchanged. Failure evidence lists every probed path:

\`\`\`
Pattern 'ssh_target:\s+\S+' not matched (not found: /repo/.claudechic/mcp_tools/cluster.yaml; pattern not in /home/user/.claudechic/mcp_tools/cluster.yaml)
\`\`\`

### 3. \`cluster_setup.yaml\` advance checks use \`paths\`

The two \`file-content-check\` advance steps (Phase 1 \`ssh_target\`, Phase 4 \`backend\`) now mirror the runtime loader's project-tier > user-tier priority:

\`\`\`yaml
- type: file-content-check
  paths:
    - ".claudechic/mcp_tools/cluster.yaml"
    - "~/.claudechic/mcp_tools/cluster.yaml"
  pattern: "ssh_target:\\s+\\S+"
\`\`\`

## Test plan

14 new tests in \`tests/test_checks_tier_aware.py\`:

- [x] \`_resolve_against\`: \`~\` expansion before absolute check; relative paths still join base_dir; absolute paths unchanged.
- [x] \`FileExistsCheck\`: multi-path first-match, all-missing diagnostic, single-path back-compat, raises on neither path nor paths.
- [x] \`FileContentCheck\`: multi-path first-match, project-tier-wins-when-both-match (priority pin), all-missing diagnostic with per-path reasons, single-path back-compat, raises on empty pattern.
- [x] Registry smoke tests: \`paths\` passes through the lambda factories; an end-to-end shape mirroring the cluster_setup advance check (project-tier missing, user-tier matches) actually succeeds.
- [x] Full suite 900 passed (was 886; +14 new). Adjacent areas (checks, workflows, advance, cluster) all green.
- [x] \`ruff check\` + \`ruff format\` clean. Pyright clean.

## Out of scope

- \`command-output-check\` keeps its single \`command\` parameter -- there's no symmetric \"any of these commands\" use case yet.
- The cluster_setup workflow's \`apply.md\`/\`detect.md\` already document the dual-tier story (post-#50). No textual changes needed here.

Closes the asymmetry surfaced after #50 -- runtime loader and advance checks now agree on what counts as \"configured\".

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>