### PR TITLE
feat(diff): strip directory prefix from file rows in directory sort

### DIFF
--- a/claudechic/features/diff/widgets.py
+++ b/claudechic/features/diff/widgets.py
@@ -151,47 +151,74 @@ class DiffFileItem(Static):
         status: str,
         hunk_count: int,
         hidden: bool = False,
+        display_path: str | None = None,
         **kwargs,
     ) -> None:
+        """Construct a per-file row in the diff sidebar.
+
+        ``path`` is the canonical relative path used for *identity* --
+        widget id, click/scroll target, edit-icon open target, and
+        hide-store key. It does NOT change.
+
+        ``display_path`` is what the user sees rendered in the row.
+        When ``None`` (the default), the row falls back to ``path``
+        verbatim -- preserves historical behavior for alphabetical
+        sort and root-level files.
+
+        The split lets the directory-grouping render path strip the
+        already-shown directory prefix from the visible label without
+        affecting the click/scroll/edit/hide identity layer. See
+        ``DiffSidebar._compose_directory``.
+        """
         super().__init__(**kwargs)
         self.path = path
         self.status = status
         self.hunk_count = hunk_count
         self.hidden = hidden
+        self._display_path = display_path if display_path is not None else path
         if hidden:
             self.add_class("hidden-entry")
 
-    def compose(self) -> ComposeResult:
-        # Show hunk count if > 1
+    def _label_markup(self) -> str:
+        """Build the Rich-markup string for the row's text label.
+
+        Shared between :meth:`compose` (first mount) and
+        :meth:`set_hidden` (in-place re-render after a hide-state
+        flip) so the truncation rule and render variants live in a
+        single place. Uses ``self._display_path`` so rows under a
+        directory header can show the directory-relative basename
+        while the click-target ``self.path`` keeps the full relative
+        path.
+        """
         count_str = f" ({self.hunk_count})" if self.hunk_count > 1 else ""
-        # Truncate path from front if too long (leave room for indicator + count + edit icon)
+        # Truncate from the front if too long (leave room for indicator + count + edit icon).
         max_path_len = 22
-        display_path = self.path
+        display_path = self._display_path
         if len(display_path) > max_path_len:
             display_path = "…" + display_path[-(max_path_len - 1) :]
 
         if self.hidden:
             # Hidden render variant (s7): dot status, muted+strike path,
             # muted (no-strike) hunk count. EditIcon unchanged.
-            label_markup = (
+            return (
                 f"[$text-muted].[/] "
                 f"[$text-muted strike]{display_path}[/]"
                 f"[$text-muted]{count_str}[/]"
             )
-        else:
-            # Normal status indicator -- primary color, red for deleted.
-            indicator = {
-                "modified": "M",
-                "added": "A",
-                "deleted": "D",
-                "renamed": "R",
-                "untracked": "U",
-            }.get(self.status, "?")
-            color = "$primary" if self.status != "deleted" else "$error"
-            label_markup = f"[{color}]{indicator}[/] {display_path}[dim]{count_str}[/]"
+        # Normal status indicator -- primary color, red for deleted.
+        indicator = {
+            "modified": "M",
+            "added": "A",
+            "deleted": "D",
+            "renamed": "R",
+            "untracked": "U",
+        }.get(self.status, "?")
+        color = "$primary" if self.status != "deleted" else "$error"
+        return f"[{color}]{indicator}[/] {display_path}[dim]{count_str}[/]"
 
+    def compose(self) -> ComposeResult:
         with Horizontal():
-            yield Label(label_markup, classes="file-label")
+            yield Label(self._label_markup(), classes="file-label")
             yield EditIcon(self.path)
 
     def set_hidden(self, hidden: bool, tooltip: str | None = None) -> None:
@@ -222,31 +249,11 @@ class DiffFileItem(Static):
             hbox.remove()
         # Re-mount via mount() since compose() is only called at first
         # mount; mounting the children manually applies the new render
-        # variant immediately.
-        count_str = f" ({self.hunk_count})" if self.hunk_count > 1 else ""
-        max_path_len = 22
-        display_path = self.path
-        if len(display_path) > max_path_len:
-            display_path = "…" + display_path[-(max_path_len - 1) :]
-        if hidden:
-            label_markup = (
-                f"[$text-muted].[/] "
-                f"[$text-muted strike]{display_path}[/]"
-                f"[$text-muted]{count_str}[/]"
-            )
-        else:
-            indicator = {
-                "modified": "M",
-                "added": "A",
-                "deleted": "D",
-                "renamed": "R",
-                "untracked": "U",
-            }.get(self.status, "?")
-            color = "$primary" if self.status != "deleted" else "$error"
-            label_markup = f"[{color}]{indicator}[/] {display_path}[dim]{count_str}[/]"
+        # variant immediately. ``self.hidden`` was already updated above
+        # so ``_label_markup`` returns the correct variant.
         hbox = Horizontal()
         self.mount(hbox)
-        hbox.mount(Label(label_markup, classes="file-label"))
+        hbox.mount(Label(self._label_markup(), classes="file-label"))
         hbox.mount(EditIcon(self.path))
         self.tooltip = tooltip
 
@@ -521,7 +528,15 @@ class DiffSidebar(Vertical):
                 yield from self._compose_file_item(node, indent=False)
 
     def _compose_directory(self, node: DirectoryNode):
-        """Yield a DiffDirectoryItem header followed by its file rows."""
+        """Yield a DiffDirectoryItem header followed by its file rows.
+
+        Children are rendered with ``display_prefix=node.prefix`` so the
+        rows show the directory-relative basename (e.g. ``foo.py``)
+        instead of repeating the prefix already shown in the header
+        above (``src/foo.py`` -> ``foo.py`` under a ``src/`` header).
+        Click/scroll/edit identity stays full-path; only the visible
+        label is shortened.
+        """
         is_hidden = self._hide_state.is_prefix_hidden(node.prefix)
         is_folded = self._hide_state.is_folded(node.prefix)
         yield DiffDirectoryItem(
@@ -532,19 +547,43 @@ class DiffSidebar(Vertical):
         )
         for child in node.children:
             if isinstance(child, FileNode):
-                file_item_gen = self._compose_file_item(child, indent=True)
+                file_item_gen = self._compose_file_item(
+                    child, indent=True, display_prefix=node.prefix
+                )
                 for item in file_item_gen:
                     if is_folded:
                         item.display = False
                     yield item
 
-    def _compose_file_item(self, file_node: FileNode, *, indent: bool):
-        """Yield a DiffFileItem for a FileNode."""
+    def _compose_file_item(
+        self,
+        file_node: FileNode,
+        *,
+        indent: bool,
+        display_prefix: str = "",
+    ):
+        """Yield a DiffFileItem for a FileNode.
+
+        ``display_prefix``, when non-empty, is the parent directory
+        prefix that will be stripped from the rendered label so the
+        row reads as the directory-relative basename. Defensively
+        only strips when the path actually starts with the prefix --
+        guards against tree shapes where the rule does not hold.
+        Identity (``DiffFileItem.path``) is always the full relative
+        path; only the displayed text changes.
+        """
         change = file_node.file_change
         tooltip = (
             _hidden_tooltip(change.path, self._hide_state) if file_node.hidden else None
         )
         classes = "dir-file-item" if indent else ""
+        display_path: str | None = None
+        if display_prefix and change.path.startswith(display_prefix):
+            stripped = change.path[len(display_prefix) :]
+            # Belt-and-suspenders: never render an empty label, fall
+            # back to the full path if stripping would leave nothing.
+            if stripped:
+                display_path = stripped
         item = DiffFileItem(
             change.path,
             change.status,
@@ -552,6 +591,7 @@ class DiffSidebar(Vertical):
             hidden=file_node.hidden,
             id=_path_to_id(change.path),
             classes=classes,
+            display_path=display_path,
         )
         if tooltip is not None:
             item.tooltip = tooltip

--- a/tests/test_diff_dir_strip.py
+++ b/tests/test_diff_dir_strip.py
@@ -1,0 +1,210 @@
+"""Diff sidebar: strip the redundant directory prefix from file rows.
+
+In directory-sort mode, the sidebar renders a ``DiffDirectoryItem``
+header (showing the prefix, e.g. ``src/``) followed by file rows.
+Historical behavior re-rendered the full relative path inside each
+row (``src/foo.py``), so the directory name was visually doubled --
+once in the header and once in every row beneath it.
+
+This module pins the new behavior:
+
+1. ``DiffFileItem`` accepts an optional ``display_path`` constructor
+   parameter. When set, that string drives the rendered label.
+   When not set, falls back to ``self.path`` (alphabetical sort and
+   root-level files).
+
+2. ``DiffSidebar._compose_directory`` passes the basename to children
+   via ``display_path = change.path[len(node.prefix):]``. So
+   ``src/foo.py`` under a ``src/`` header renders as ``foo.py``.
+
+3. Identity (``DiffFileItem.path``) is *unchanged* -- the click
+   target, scroll target, edit-icon target, hide-store key, and DOM
+   id all still use the full relative path. Only the visible text
+   changes. Tests reach inside the widget's internal label to
+   verify what the user sees.
+"""
+
+from __future__ import annotations
+
+from claudechic.features.diff.git import FileChange
+from claudechic.features.diff.tree import DirectoryNode, FileNode
+from claudechic.features.diff.widgets import DiffFileItem, DiffSidebar
+
+
+# ---------------------------------------------------------------------------
+# Unit: DiffFileItem display_path parameter
+# ---------------------------------------------------------------------------
+
+
+def test_diff_file_item_defaults_display_to_path() -> None:
+    """No ``display_path`` -> render text equals the canonical path.
+    Back-compat for alphabetical sort and root-level files."""
+    item = DiffFileItem("src/foo.py", "modified", hunk_count=1)
+    assert item._display_path == "src/foo.py"
+    # Identity unchanged.
+    assert item.path == "src/foo.py"
+
+
+def test_diff_file_item_uses_explicit_display_path() -> None:
+    """Explicit ``display_path`` -> render text uses it; identity
+    keeps the canonical full path so click/scroll/edit lookups still
+    resolve."""
+    item = DiffFileItem(
+        "src/foo.py",
+        "modified",
+        hunk_count=1,
+        display_path="foo.py",
+    )
+    assert item._display_path == "foo.py"
+    assert item.path == "src/foo.py"
+
+
+def test_diff_file_item_label_markup_uses_display_path() -> None:
+    """``_label_markup`` returns Rich markup containing the display
+    path (basename), not the canonical path. Catches a regression
+    where ``compose`` / ``set_hidden`` start using ``self.path``
+    directly again instead of the helper."""
+    item = DiffFileItem(
+        "src/lib/widgets/foo.py",
+        "modified",
+        hunk_count=1,
+        display_path="foo.py",
+    )
+    markup = item._label_markup()
+    assert "foo.py" in markup
+    # The directory prefix must NOT appear -- if it does, we are
+    # rendering the full path and the dir name doubles up.
+    assert "src/" not in markup
+    assert "lib/" not in markup
+
+
+def test_diff_file_item_label_markup_truncation_uses_display_path() -> None:
+    """The 22-char truncation rule applies to the display string,
+    not to the canonical path. A long full path with a short
+    display_path should render the short string in full."""
+    item = DiffFileItem(
+        "deeply/nested/very/long/directory/structure/foo.py",
+        "modified",
+        hunk_count=1,
+        display_path="foo.py",  # short -- should NOT get truncated
+    )
+    markup = item._label_markup()
+    assert "foo.py" in markup
+    assert "…" not in markup, (
+        "short display_path should not trigger the front-truncation rule"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: DiffSidebar._compose_directory passes the right prefix
+# ---------------------------------------------------------------------------
+
+
+def _make_sidebar_with_dir(prefix: str, file_paths: list[str]) -> DiffSidebar:
+    """Build a DiffSidebar containing one DirectoryNode + given files.
+
+    The sidebar is constructed but NOT mounted; tests inspect the
+    composed children via the same generator the runtime uses, so
+    they don't need a Textual app context.
+    """
+    from claudechic.features.diff.hide import HideState
+
+    files = [
+        FileNode(file_change=FileChange(path=p, status="modified", hunks=[]))
+        for p in file_paths
+    ]
+    tree = [DirectoryNode(prefix=prefix, children=files)]
+    return DiffSidebar(tree=tree, hide_state=HideState())
+
+
+def test_compose_directory_strips_prefix_from_children() -> None:
+    """End-to-end: a directory with two files yields one
+    DiffDirectoryItem header and two DiffFileItems whose
+    ``_display_path`` is the basename, not the full path."""
+    sidebar = _make_sidebar_with_dir("src/", ["src/foo.py", "src/bar.py"])
+    node = sidebar._tree[0]  # the DirectoryNode
+    assert isinstance(node, DirectoryNode)
+
+    items = list(sidebar._compose_directory(node))
+    # First yield is the header; subsequent yields are file rows.
+    file_items = [i for i in items if isinstance(i, DiffFileItem)]
+    assert len(file_items) == 2
+
+    by_canonical = {i.path: i for i in file_items}
+    # Identity is the full path -- preserved for click/scroll/edit.
+    assert set(by_canonical) == {"src/foo.py", "src/bar.py"}
+    # Rendered display is the directory-relative basename.
+    assert by_canonical["src/foo.py"]._display_path == "foo.py"
+    assert by_canonical["src/bar.py"]._display_path == "bar.py"
+
+
+def test_compose_directory_handles_nested_prefix() -> None:
+    """Multi-segment prefix like ``src/lib/`` still strips correctly,
+    leaving the remainder regardless of depth."""
+    sidebar = _make_sidebar_with_dir("src/lib/", ["src/lib/widgets/foo.py"])
+    node = sidebar._tree[0]
+    assert isinstance(node, DirectoryNode)
+
+    items = [i for i in sidebar._compose_directory(node) if isinstance(i, DiffFileItem)]
+    assert len(items) == 1
+    assert items[0].path == "src/lib/widgets/foo.py"
+    assert items[0]._display_path == "widgets/foo.py", (
+        "stripping is whole-prefix, not greedy basename -- the file's "
+        "remaining sub-path under the directory header should show in full"
+    )
+
+
+def test_compose_file_item_no_prefix_keeps_full_path() -> None:
+    """Top-level call (alphabetical sort or root-level files in
+    directory mode) -- no display_prefix passed, so the file row
+    keeps the full canonical path as its display string."""
+    from claudechic.features.diff.hide import HideState
+
+    file_change = FileChange(path="README.md", status="modified", hunks=[])
+    file_node = FileNode(file_change=file_change)
+    sidebar = DiffSidebar(tree=[file_node], hide_state=HideState())
+
+    items = list(sidebar._compose_file_item(file_node, indent=False))
+    assert len(items) == 1
+    item = items[0]
+    assert item.path == "README.md"
+    assert item._display_path == "README.md"
+
+
+def test_compose_file_item_defensive_when_path_does_not_start_with_prefix() -> None:
+    """Defensive: if the file path does not actually start with the
+    directory prefix (shouldn't happen in well-formed trees, but
+    guard against it) the row falls back to the full path so the
+    user always sees something accurate."""
+    from claudechic.features.diff.hide import HideState
+
+    file_change = FileChange(path="other/foo.py", status="modified", hunks=[])
+    file_node = FileNode(file_change=file_change)
+    sidebar = DiffSidebar(tree=[file_node], hide_state=HideState())
+
+    items = list(
+        sidebar._compose_file_item(file_node, indent=True, display_prefix="src/")
+    )
+    assert len(items) == 1
+    assert items[0]._display_path == "other/foo.py", (
+        "when path doesn't start with the prefix, we must NOT silently "
+        "produce a misleading label -- fall back to the full canonical path"
+    )
+
+
+def test_compose_file_item_defensive_when_strip_would_be_empty() -> None:
+    """Edge case: if the prefix matches the entire path (a directory
+    node whose only child has the same exact name), stripping would
+    leave an empty string. The renderer must NOT show an empty
+    label -- fall back to the full path."""
+    from claudechic.features.diff.hide import HideState
+
+    file_change = FileChange(path="src/", status="modified", hunks=[])
+    file_node = FileNode(file_change=file_change)
+    sidebar = DiffSidebar(tree=[file_node], hide_state=HideState())
+
+    items = list(
+        sidebar._compose_file_item(file_node, indent=True, display_prefix="src/")
+    )
+    assert len(items) == 1
+    assert items[0]._display_path == "src/"


### PR DESCRIPTION
## Why

In directory-sort mode the diff sidebar repeated the directory prefix in every row, so under a \`src/\` header a row read \`M src/foo.py\` -- the directory name appeared twice in the same vertical slice of the screen. With deep paths (\`claudechic/widgets/content/foo.py\`) the rendered label was mostly directory and the filename was hard to scan.

## What changed

Three coupled changes in \`claudechic/features/diff/widgets.py\`:

### 1. \`DiffFileItem\` decouples identity from display

New optional \`display_path\` constructor parameter. When set, drives the rendered label. When omitted (alphabetical sort, root-level files), the row falls back to \`self.path\` -- back-compat preserved.

Crucially, \`self.path\` stays the full relative path. It is the:
- DOM id key (\`_path_to_id(self.path)\`)
- Click/scroll target (\`Selected\`/\`Clicked\`/\`UnhideRequested\` messages)
- Edit-icon open target
- Hide-store key

So nothing downstream of the click/scroll/hide layer changes.

### 2. \`compose()\` and \`set_hidden()\` share a single \`_label_markup()\` helper

\`set_hidden()\` historically duplicated the truncation + status-indicator + hidden-variant markup logic. Refactored into one helper that both call. Net code is smaller AND the new \`display_path\` plumbing only had to land in one place.

### 3. \`_compose_directory\` passes the prefix down

\`DiffSidebar._compose_directory\` now passes \`display_prefix=node.prefix\` to \`_compose_file_item\`, which strips it from \`change.path\` before constructing the \`DiffFileItem\`. Defensive guards:
- Only strips when \`change.path.startswith(display_prefix)\` actually holds.
- Never produces an empty label -- falls back to the full path if stripping would empty out.

Top-level calls (alphabetical sort) don't pass \`display_prefix\` at all, so they keep the full path.

## Test plan

9 new tests in \`tests/test_diff_dir_strip.py\`:

- [x] \`DiffFileItem\` defaults \`_display_path\` to \`path\` (back-compat).
- [x] Explicit \`display_path\` is used; \`self.path\` unchanged (identity preserved).
- [x] \`_label_markup()\` rendered text contains the display string and **does not** contain the directory prefix that would otherwise double up.
- [x] 22-char truncation rule applies to the display string, not the canonical path -- a long full path with a short \`display_path\` renders the short string in full (no \`…\` ellipsis).
- [x] \`_compose_directory\` of a real \`DirectoryNode\` strips the prefix from each child's display.
- [x] Multi-segment prefix (\`src/lib/\`) strips the whole prefix, leaving the file's remaining sub-path under the header.
- [x] Top-level / alphabetical mode (\`indent=False\`, no \`display_prefix\`) keeps the full canonical path.
- [x] Defensive: file path that does not start with the prefix falls back to full path (no misleading label).
- [x] Defensive: prefix matching the entire path (would-be empty strip) falls back to full path.
- [x] Adjacent: \`tests/test_diff.py\` + \`tests/test_diff_workflows.py\` (20 tests) still pass -- they query \`DiffFileItem\` by id derived from the full path, which is unchanged.
- [x] Full suite 909 passed (was 906; +9 new). \`ruff check\` + \`ruff format\` + pyright clean.

## Visual effect

\`\`\`
before                       after
------                       -----
src/                         src/
  M src/foo.py                 M foo.py
  M src/bar.py                 M bar.py
tests/                       tests/
  M tests/test_foo.py          M test_foo.py
\`\`\`

Reviewed live in the TUI before commit -- indentation under directory headers is preserved by the existing \`.dir-file-item\` CSS class.

## Out of scope

- The \`DiffDirectoryItem\` header itself is unchanged; it already shows the prefix in its own widget.
- \`FilesSection\` (the sidebar in the main chat view, separate from the \`/diff\` screen) does not group by directory and is not affected.
- The truncation max-length (22) is unchanged. With basenames it's now hit far less often, which was the goal.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>