### PR TITLE
feat(worktree): user-approved copy fallback when symlink propagation fails

### DIFF
--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -44,6 +44,12 @@ def _load() -> tuple[dict, bool]:
         config.setdefault("experimental", {})
         config.setdefault("worktree", {})
         config["worktree"].setdefault("path_template", None)
+        # Behavior when symlink propagation of .claude/.claudechic into a new
+        # worktree fails with OSError (typically Windows without Developer Mode,
+        # FAT32, etc.). Valid: "ask" | "copy" | "abort". Default "ask" means
+        # surface a prompt; "copy" / "abort" suppress the prompt with the
+        # corresponding action. See sprustonlab/claudechic#26.
+        config["worktree"].setdefault("symlink_fallback", "ask")
         config.setdefault("default_permission_mode", "auto")
         config.setdefault(
             "show_message_metadata", True
@@ -68,7 +74,7 @@ def _load() -> tuple[dict, bool]:
         config = {
             "analytics": {"enabled": True, "id": str(uuid.uuid4())},
             "experimental": {},
-            "worktree": {"path_template": None},
+            "worktree": {"path_template": None, "symlink_fallback": "ask"},
             "recent-tools-expanded": 2,
             "default_permission_mode": "auto",
             "show_message_metadata": True,  # Show timestamp/tokens by default
@@ -359,6 +365,31 @@ class ProjectConfig:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)
             raise
+
+
+_SYMLINK_FALLBACK_VALUES = ("ask", "copy", "abort")
+
+
+def get_symlink_fallback(config: dict | None = None) -> str:
+    """Return the validated worktree.symlink_fallback setting.
+
+    Reads from the user-tier CONFIG by default; tests can pass an explicit
+    dict. Invalid values log a WARNING and are treated as ``"ask"`` so a
+    typo can never silently degrade to "abort" or "copy" without consent.
+
+    Returns one of ``"ask" | "copy" | "abort"``.
+    """
+    cfg = CONFIG if config is None else config
+    raw = cfg.get("worktree", {}).get("symlink_fallback", "ask")
+    if raw in _SYMLINK_FALLBACK_VALUES:
+        return raw
+    log.warning(
+        "worktree.symlink_fallback: invalid value %r; expected one of %s. "
+        "Falling back to 'ask'.",
+        raw,
+        _SYMLINK_FALLBACK_VALUES,
+    )
+    return "ask"
 
 
 def _segment_to_yaml(seg: dict[str, Any]) -> dict[str, Any]:

--- a/claudechic/features/worktree/commands.py
+++ b/claudechic/features/worktree/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -314,8 +315,15 @@ async def on_response_complete_finish(app: ChatApp, agent: Agent) -> None:
         _run_cleanup(app, agent)
 
 
-def _switch_or_create_worktree(app: ChatApp, feature_name: str) -> None:
-    """Switch to existing worktree agent or create new one."""
+@work(group="worktree_create", exclusive=False, exit_on_error=False)
+async def _switch_or_create_worktree(app: ChatApp, feature_name: str) -> None:
+    """Switch to existing worktree agent or create new one.
+
+    Async because creating a worktree may need to prompt the user when
+    symlink propagation fails (Windows without Developer Mode etc.; see
+    issue #26). The prompt path runs only on ``OSError``; the POSIX
+    happy path completes without ever yielding for input.
+    """
     # Check if we already have an agent for this worktree
     for agent in app.agents.values():
         if agent.worktree == feature_name:
@@ -331,15 +339,58 @@ def _switch_or_create_worktree(app: ChatApp, feature_name: str) -> None:
         app._create_new_agent(
             feature_name, wt.path, worktree=feature_name, auto_resume=True
         )
+        return
+
+    # Create new worktree. ``start_worktree`` is synchronous (subprocess
+    # calls + filesystem ops) and runs in a worker thread via
+    # ``asyncio.to_thread``. If symlink propagation hits a non-recoverable
+    # OSError it invokes the sync callback below, which round-trips to
+    # the main loop to mount the prompt and awaits the user's choice.
+    loop = asyncio.get_running_loop()
+
+    async def _ask_user(name: str, error: OSError) -> str:
+        return await _show_symlink_fallback_prompt(app, name, error)
+
+    def _sync_fallback(name: str, error: OSError) -> str:
+        future = asyncio.run_coroutine_threadsafe(_ask_user(name, error), loop)
+        return future.result()
+
+    success, message, new_cwd = await asyncio.to_thread(
+        start_worktree, feature_name, _sync_fallback
+    )
+    if success and new_cwd:
+        app._create_new_agent(
+            feature_name, new_cwd, worktree=feature_name, auto_resume=False
+        )
     else:
-        # Create new worktree
-        success, message, new_cwd = start_worktree(feature_name)
-        if success and new_cwd:
-            app._create_new_agent(
-                feature_name, new_cwd, worktree=feature_name, auto_resume=False
-            )
-        else:
-            app.notify(message, severity="error")
+        app.notify(message, severity="error")
+
+
+async def _show_symlink_fallback_prompt(
+    app: ChatApp, source_name: str, error: OSError
+) -> str:
+    """Mount ``SymlinkFallbackPrompt`` and return the user's choice.
+
+    Returns ``"copy"`` or ``"abort"``. Cancellation defaults to
+    ``"abort"`` (the prompt itself enforces this) so that closing the
+    prompt without an answer cannot silently degrade to a copy without
+    consent. See issue #26.
+    """
+    from claudechic.widgets import ChatInput, SymlinkFallbackPrompt
+
+    prompt = SymlinkFallbackPrompt(source_name, error)
+    async with app._show_prompt(prompt):
+        prompt.focus()
+        result = await prompt.wait()
+
+    with contextlib.suppress(Exception):
+        app.query_one("#input", ChatInput).focus()
+
+    # ``SymlinkFallbackPrompt.wait`` returns ``"copy"`` or ``"abort"``;
+    # treat anything else (defensive) as abort.
+    if result not in ("copy", "abort"):
+        return "abort"
+    return result
 
 
 def _close_agents_for_branches(app: ChatApp, branches: list[str]) -> None:

--- a/claudechic/features/worktree/git.py
+++ b/claudechic/features/worktree/git.py
@@ -1,11 +1,28 @@
 """Git worktree management for isolated feature work."""
 
+import contextlib
+import logging
+import shutil
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 
-from claudechic.config import CONFIG
+from claudechic.config import CONFIG, get_symlink_fallback
+
+log = logging.getLogger(__name__)
+
+# Names of state directories propagated from the main worktree into a new
+# worktree. Order matters for the prompt-once-apply-to-all behavior in
+# ``_propagate_state_sync``: ``.claude`` is attempted first.
+_PROPAGATED_STATE_DIRS = (".claude", ".claudechic")
+
+# Decision callback contract. Invoked when ``Path.symlink_to`` raises an
+# OSError other than FileExistsError (typically Windows without Developer
+# Mode, FAT32, etc.). Receives the source dir name (e.g. ".claudechic") and
+# the OSError, and must return ``"copy"`` or ``"abort"``. See #26.
+SymlinkFallbackCallback = Callable[[str, OSError], str]
 
 
 class FinishPhase(Enum):
@@ -258,8 +275,22 @@ def _expand_worktree_path(template: str, repo_name: str, feature_name: str) -> P
     return path.resolve()
 
 
-def start_worktree(feature_name: str) -> tuple[bool, str, Path | None]:
+def start_worktree(
+    feature_name: str,
+    on_symlink_fallback: SymlinkFallbackCallback | None = None,
+) -> tuple[bool, str, Path | None]:
     """Create a worktree for the given feature.
+
+    Args:
+        feature_name: Branch / feature name for the new worktree.
+        on_symlink_fallback: Optional callback invoked when symlink
+            propagation fails with a non-FileExistsError ``OSError``.
+            Must return ``"copy"`` (snapshot the source dir into the
+            worktree, semantics diverge thereafter) or ``"abort"`` (roll
+            back the worktree creation). When omitted, the configured
+            ``worktree.symlink_fallback`` value is consulted; if that
+            resolves to ``"ask"`` and no callback is provided the call
+            defensively aborts to avoid silent degradation. See #26.
 
     Returns (success, message, worktree_path).
     """
@@ -290,27 +321,21 @@ def start_worktree(feature_name: str) -> tuple[bool, str, Path | None]:
             text=True,
         )
 
-        # Symlink .claude/ and .claudechic/ from main worktree so hooks,
+        # Propagate .claude/ and .claudechic/ from main worktree so hooks,
         # skills, local settings, hint state, and project config carry over
-        # (they're typically gitignored). Race-safe via try/except FileExistsError
-        # per SPEC.md §10.2 — both blocks use the same pattern.
+        # (they're typically gitignored). Symlink is the preferred mechanism
+        # (live propagation); copy is the user-approved fallback when symlinks
+        # are unavailable. See SPEC.md §10.2 and issue #26.
         main_wt_info = get_main_worktree()
-        if main_wt_info:
-            source_claude_dir = main_wt_info[0] / ".claude"
-            if source_claude_dir.is_dir():
-                target = worktree_dir / ".claude"
-                try:
-                    target.symlink_to(source_claude_dir.resolve())
-                except FileExistsError:
-                    pass
-
-            source_claudechic_dir = main_wt_info[0] / ".claudechic"
-            if source_claudechic_dir.is_dir():
-                target = worktree_dir / ".claudechic"
-                try:
-                    target.symlink_to(source_claudechic_dir.resolve())
-                except FileExistsError:
-                    pass
+        if main_wt_info is not None:
+            ok, msg = _propagate_state_sync(
+                source_root=main_wt_info[0],
+                target_root=worktree_dir,
+                on_symlink_fallback=on_symlink_fallback,
+            )
+            if not ok:
+                _rollback_worktree(worktree_dir)
+                return False, msg, None
 
         return True, f"Created worktree at {worktree_dir}", worktree_dir
 
@@ -318,6 +343,107 @@ def start_worktree(feature_name: str) -> tuple[bool, str, Path | None]:
         return False, f"Git error: {e.stderr}", None
     except Exception as e:
         return False, f"Error: {e}", None
+
+
+def _propagate_state_sync(
+    *,
+    source_root: Path,
+    target_root: Path,
+    on_symlink_fallback: SymlinkFallbackCallback | None,
+) -> tuple[bool, str]:
+    """Symlink (or copy on user-approved fallback) state dirs into a worktree.
+
+    For each name in ``_PROPAGATED_STATE_DIRS`` that exists under
+    ``source_root``, attempt ``Path.symlink_to``. Behavior on errors:
+
+    - ``FileExistsError`` -- target already exists; idempotent no-op.
+    - other ``OSError`` -- consult ``worktree.symlink_fallback`` config.
+      If the resolved policy is ``"ask"``, invoke ``on_symlink_fallback``
+      (returns ``"copy"`` or ``"abort"``). If ``on_symlink_fallback`` is
+      ``None`` and the policy is ``"ask"``, treat as ``"abort"`` (never
+      silently copy). The first non-FileExistsError fixes the policy for
+      remaining sources within this call: the user is prompted at most
+      once, and "copy" / "abort" choices apply uniformly to every
+      remaining source dir.
+
+    Returns ``(ok, message)``. ``ok=False`` signals abort -- the caller
+    is expected to roll back the partially-created worktree.
+    """
+    sources = [
+        (name, source_root / name)
+        for name in _PROPAGATED_STATE_DIRS
+        if (source_root / name).is_dir()
+    ]
+    if not sources:
+        return True, ""
+
+    # Cache the user's decision once they've been prompted, so we don't
+    # ask twice for back-to-back failures within the same worktree creation.
+    sticky_decision: str | None = None
+
+    for name, source in sources:
+        target = target_root / name
+        resolved_source = source.resolve()
+        try:
+            target.symlink_to(resolved_source)
+            continue
+        except FileExistsError:
+            continue
+        except OSError as err:
+            decision = sticky_decision
+            if decision is None:
+                decision = get_symlink_fallback()
+                if decision == "ask":
+                    if on_symlink_fallback is None:
+                        log.warning(
+                            "Symlink propagation failed for %s and no "
+                            "fallback callback provided; aborting "
+                            "worktree creation: %s",
+                            name,
+                            err,
+                        )
+                        decision = "abort"
+                    else:
+                        decision = on_symlink_fallback(name, err)
+                sticky_decision = decision
+
+            if decision == "copy":
+                shutil.copytree(source, target, symlinks=False)
+            elif decision == "abort":
+                return False, (
+                    f"Worktree creation aborted: cannot create symlink "
+                    f"for {name} ({err})"
+                )
+            else:
+                # Defensive: unknown decision string -> abort, don't trust it.
+                log.warning("Unknown symlink fallback decision %r; aborting", decision)
+                return False, (
+                    f"Worktree creation aborted: unknown fallback decision {decision!r}"
+                )
+
+    return True, ""
+
+
+def _rollback_worktree(worktree_dir: Path) -> None:
+    """Best-effort cleanup of a partially-created worktree.
+
+    Called from ``start_worktree`` when state propagation aborts. We try
+    ``git worktree remove --force`` first so git's metadata is cleaned;
+    if anything is left behind we ``rmtree`` the directory. All failures
+    are swallowed (logged) -- this is recovery code, not a guarantee.
+    """
+    try:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_dir)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:
+        log.exception("git worktree remove failed during rollback")
+    if worktree_dir.exists():
+        with contextlib.suppress(OSError):
+            shutil.rmtree(worktree_dir)
 
 
 def get_finish_info(cwd: Path | None = None) -> tuple[bool, str, FinishInfo | None]:

--- a/claudechic/widgets/__init__.py
+++ b/claudechic/widgets/__init__.py
@@ -83,6 +83,7 @@ from claudechic.widgets.prompts import (
     ModelPrompt,
     QuestionPrompt,
     SelectionPrompt,
+    SymlinkFallbackPrompt,
     UncommittedChangesPrompt,
     WorktreePrompt,
 )
@@ -163,4 +164,5 @@ __all__ = [
     "ModelPrompt",
     "WorktreePrompt",
     "UncommittedChangesPrompt",
+    "SymlinkFallbackPrompt",
 ]

--- a/claudechic/widgets/prompts.py
+++ b/claudechic/widgets/prompts.py
@@ -501,6 +501,72 @@ class WorktreePrompt(BasePrompt):
         return self._result_value
 
 
+class SymlinkFallbackPrompt(BasePrompt):
+    """Prompt shown when symlinking ``.claude``/``.claudechic`` into a new worktree fails.
+
+    Two options: ``"copy"`` (snapshot the source dir; future edits diverge)
+    or ``"abort"`` (roll back the worktree creation). Skip is intentionally
+    omitted -- a Windows user who hits this prompt is hitting it *because*
+    they want their state propagated. See sprustonlab/claudechic#26.
+    """
+
+    def __init__(self, source_name: str, error: OSError) -> None:
+        """Create the prompt.
+
+        Args:
+            source_name: Directory whose symlink failed (".claude" or ".claudechic").
+            error: The ``OSError`` raised by ``Path.symlink_to``; its
+                string form appears in the subtitle so the user can see
+                what they're consenting to.
+        """
+        super().__init__()
+        self.source_name = source_name
+        self.error = error
+
+    def compose(self) -> ComposeResult:
+        # 1 top + title + subtitle + 2 options + 1 bottom = 6 rows minimum.
+        self.styles.min_height = 6
+        yield Static(
+            f"Symlink failed for {self.source_name}",
+            classes="prompt-title",
+            markup=False,
+        )
+        yield Static(
+            f"OSError: {self.error}",
+            classes="prompt-subtitle",
+            markup=False,
+        )
+        yield Static(
+            "1. Copy current contents (won't sync future edits)",
+            classes="prompt-option selected",
+            id="opt-0",
+            markup=False,
+        )
+        yield Static(
+            "2. Abort worktree creation",
+            classes="prompt-option",
+            id="opt-1",
+            markup=False,
+        )
+
+    def _total_options(self) -> int:
+        return 2
+
+    def _select_option(self, idx: int) -> None:
+        choices = ("copy", "abort")
+        self._resolve(choices[idx])
+
+    def cancel(self) -> None:
+        # Escape -> abort. Cancelling the prompt without an answer cannot
+        # silently degrade to copy; the safe default is "no consent" -> abort.
+        self._resolve("abort")
+
+    async def wait(self) -> str:
+        """Returns ``"copy"`` or ``"abort"``."""
+        await super().wait()
+        return self._result_value
+
+
 class UncommittedChangesPrompt(BasePrompt):
     """Prompt for handling uncommitted changes during worktree finish."""
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,35 @@ worktree:
   path_template: $HOME/worktrees/${repo_name}-${branch_name}
 ```
 
+### `worktree.symlink_fallback`
+
+- **Type:** `string` (`"ask"` | `"copy"` | `"abort"`)
+- **Default:** `"ask"`
+- **Exposed in `/settings`:** no
+
+Controls what happens when a new worktree's `.claude/` and `.claudechic/`
+state cannot be propagated via symlink (typically Windows without
+Developer Mode enabled, FAT32/exFAT filesystems, or network shares
+without symlink evaluation). On POSIX with working symlinks this
+setting is never consulted -- the live symlink path always wins.
+
+| Value | Behavior on `OSError` |
+|-------|-----------------------|
+| `"ask"` (default) | Show a prompt: copy or abort. |
+| `"copy"` | Snapshot the source dir into the worktree. Future edits to the source do **not** propagate. |
+| `"abort"` | Roll back the worktree creation and report failure. |
+
+The `"ask"` default is deliberately conservative: with no consent
+channel wired up (e.g., headless tooling), it falls back to `"abort"`
+rather than silently degrading to a copy. Explicit consent is required
+for the snapshot semantics, since copy and symlink behave differently
+once the source dir changes.
+
+```yaml
+worktree:
+  symlink_fallback: copy
+```
+
 ### `analytics.enabled`
 
 - **Type:** `boolean`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -448,3 +448,62 @@ def test_build_gate_settings_project_tier_overrides_user_tier(tmp_path):
     # Project tier wins: compact=False overrides user's True; sites narrowed to {spawn}.
     assert settings.constraints_segment.compact is False
     assert settings.constraints_segment.sites == frozenset({"spawn"})
+
+
+# ---------------------------------------------------------------------------
+# get_symlink_fallback (issue #26): worktree.symlink_fallback validation.
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkFallbackConfig:
+    """Validate the worktree.symlink_fallback config helper (issue #26).
+
+    Two tests cover the contract:
+
+    1. ``test_valid_values_pass_through`` (parametrized) -- each of the
+       three valid policies returns as-is, and missing keys / sections
+       default to ``"ask"`` (the safe baseline).
+    2. ``test_invalid_value_warns_and_falls_back_to_ask`` -- typo guard.
+       Invalid values must NOT silently degrade; they log a WARNING and
+       fall back to ``"ask"``, which itself defensively aborts when no
+       callback is wired up (see ``test_no_consent_channel_aborts_safely``
+       in test_worktree_symlink.py).
+    """
+
+    @pytest.mark.parametrize(
+        "cfg,expected",
+        [
+            ({}, "ask"),  # fully empty -> default
+            ({"unrelated": True}, "ask"),  # no worktree section
+            ({"worktree": {"path_template": None}}, "ask"),  # no fallback key
+            ({"worktree": {"symlink_fallback": "ask"}}, "ask"),
+            ({"worktree": {"symlink_fallback": "copy"}}, "copy"),
+            ({"worktree": {"symlink_fallback": "abort"}}, "abort"),
+        ],
+        ids=[
+            "empty",
+            "no-worktree-section",
+            "no-fallback-key",
+            "ask",
+            "copy",
+            "abort",
+        ],
+    )
+    def test_valid_values_pass_through(self, cfg, expected):
+        from claudechic.config import get_symlink_fallback
+
+        assert get_symlink_fallback(cfg) == expected
+
+    def test_invalid_value_warns_and_falls_back_to_ask(self, caplog):
+        """Typo guard: unknown value -> 'ask' + WARNING."""
+        import logging
+
+        from claudechic.config import get_symlink_fallback
+
+        cfg = {"worktree": {"symlink_fallback": "bogus"}}
+        with caplog.at_level(logging.WARNING, logger="claudechic.config"):
+            result = get_symlink_fallback(cfg)
+        assert result == "ask"
+        assert any("invalid value" in r.message for r in caplog.records), (
+            "Expected a WARNING about the invalid value"
+        )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -16,6 +16,7 @@ from claudechic.widgets import (
     QuestionPrompt,
     SelectionPrompt,
     StatusFooter,
+    SymlinkFallbackPrompt,
     ThinkingIndicator,
     TodoPanel,
 )
@@ -1054,6 +1055,51 @@ async def test_selection_prompt_no_subtitle():
         prompt = app.query_one(SelectionPrompt)
         subtitles = list(prompt.query(".prompt-subtitle"))
         assert len(subtitles) == 0
+
+
+# --- SymlinkFallbackPrompt tests (issue #26) ---
+#
+# One parametrized test covers the full input contract:
+#   "1" / arrow+enter -> "copy"
+#   "2"               -> "abort"
+#   "escape"          -> "abort"  (security-relevant default: dismissal
+#                                  must NEVER imply consent to copy)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        (["1"], "copy"),
+        (["2"], "abort"),
+        (["escape"], "abort"),
+        (["down", "enter"], "abort"),
+    ],
+    ids=["number-copy", "number-abort", "escape-aborts", "arrow-then-enter"],
+)
+async def test_symlink_fallback_prompt_resolves(keys, expected):
+    """Pin the two-option resolution contract for SymlinkFallbackPrompt."""
+    err = OSError("[Errno 1] mocked symlink failure")
+
+    class TestApp(App):
+        def compose(self):
+            yield SymlinkFallbackPrompt(".claudechic", err)
+
+    app = TestApp()
+    async with app.run_test() as pilot:
+        prompt = app.query_one(SymlinkFallbackPrompt)
+        # Capture the title BEFORE the prompt resolves and removes itself
+        # from the DOM. Pins that the failing dir name surfaces in the
+        # title so the user sees what they're consenting to.
+        title = prompt.query_one(".prompt-title", Static).render()
+        title_text = getattr(title, "plain", str(title))
+        assert ".claudechic" in title_text
+
+        for key in keys:
+            await pilot.press(key)
+        result = await prompt.wait()
+
+    assert result == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_worktree_symlink.py
+++ b/tests/test_worktree_symlink.py
@@ -4,6 +4,10 @@ Covers SPEC.md §10 (parallel `.claudechic/` symlink alongside the existing
 `.claude/` symlink) and the §10.2 acceptance items, plus the Skeptic2-flagged
 edge cases around the migration from ``if not target.exists()`` to the
 race-safe ``try/except FileExistsError`` pattern.
+
+The ``TestWorktreeSymlinkFallback`` class at the bottom covers the
+cross-platform OSError fallback path (issue #26) -- it runs on Windows
+too, since the OSError is mocked rather than provoked.
 """
 
 from __future__ import annotations
@@ -18,7 +22,11 @@ from claudechic.features.worktree.git import start_worktree
 
 _unix_only = pytest.mark.skipif(
     sys.platform == "win32",
-    reason="Symlinks require POSIX support; cross-platform tracking at #26",
+    reason=(
+        "Tests the symlink success path which requires Developer Mode + NTFS "
+        "on Windows; cross-platform OSError fallback is covered in "
+        "TestWorktreeSymlinkFallback below"
+    ),
 )
 
 
@@ -175,3 +183,194 @@ class TestWorktreeSymlinkPropagation:
         assert "already exists" in msg
         assert (new_wt / ".claudechic").is_symlink()
         assert (new_wt / ".claude").is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# Issue #26: cross-platform OSError fallback (copy-with-consent or abort).
+#
+# These tests run on every platform, including Windows, by mocking
+# ``Path.symlink_to`` to raise ``OSError``. They cover the user-approved
+# copy fallback, the abort path (with worktree rollback), and the
+# partial-failure case where one source dir symlinks fine and another
+# raises mid-iteration.
+# ---------------------------------------------------------------------------
+
+
+def _make_symlink_failer(should_fail):
+    """Build a function suitable for ``monkeypatch.setattr(Path, 'symlink_to', ...)``.
+
+    ``Path.symlink_to`` is a method, so the replacement must be a *function*
+    (not an arbitrary callable instance) to participate in descriptor-based
+    bound-method dispatch. ``target.symlink_to(source)`` then dispatches
+    as ``failer(target, source)``.
+
+    The returned callable carries a ``.calls`` attribute listing the targets
+    it was invoked for, so tests can assert on the prompt-once contract.
+    """
+    real = Path.symlink_to
+    calls: list[Path] = []
+
+    def failer(self, *args, **kwargs):
+        calls.append(self)
+        if should_fail(self):
+            raise OSError(f"[Errno 1] mocked symlink failure for {self.name}")
+        return real(self, *args, **kwargs)
+
+    failer.calls = calls  # type: ignore[attr-defined]
+    return failer
+
+
+@pytest.fixture
+def fail_all_symlinks(monkeypatch):
+    """Patch Path.symlink_to to raise OSError for every call into a worktree."""
+    failer = _make_symlink_failer(
+        lambda target: target.name in (".claude", ".claudechic")
+    )
+    monkeypatch.setattr(Path, "symlink_to", failer)
+    return failer
+
+
+@pytest.fixture
+def fail_only_claudechic(monkeypatch):
+    """Patch Path.symlink_to to raise OSError only for .claudechic targets."""
+    failer = _make_symlink_failer(lambda target: target.name == ".claudechic")
+    monkeypatch.setattr(Path, "symlink_to", failer)
+    return failer
+
+
+@pytest.fixture
+def reset_symlink_fallback_to_ask(monkeypatch):
+    """Ensure CONFIG['worktree']['symlink_fallback'] is 'ask' for the test.
+
+    The user's real ~/.claudechic/config.yaml could have set this to
+    'copy' or 'abort', which would silently change the meaning of tests
+    that exercise the default policy.
+    """
+    from claudechic import config as config_mod
+
+    monkeypatch.setitem(
+        config_mod.CONFIG.setdefault("worktree", {}),
+        "symlink_fallback",
+        "ask",
+    )
+
+
+class TestWorktreeSymlinkFallback:
+    """Issue #26: OSError fallback to user-approved copy or abort.
+
+    Three end-to-end tests, one per behavioral outcome:
+
+    1. ``test_user_chooses_copy`` -- user (or pre-set config) approves a
+       copy fallback. Folds in: prompt invoked exactly once, partial
+       failure (.claude symlinks fine, .claudechic copies), copy is a
+       real directory not a symlink, and snapshot semantics (later edits
+       to the source do NOT propagate -- pins the difference between
+       symlink and copy outcomes).
+
+    2. ``test_user_chooses_abort`` -- user (or pre-set config) declines
+       and aborts worktree creation. Folds in: rollback removes the
+       worktree directory, ``start_worktree`` returns failure.
+
+    3. ``test_no_consent_channel_aborts_safely`` -- OSError with no
+       callback wired up and the default ``"ask"`` policy: defensive
+       abort. Pins the security-relevant invariant that we NEVER
+       silently degrade to copy without explicit consent.
+
+    These tests do NOT depend on platform-native symlink support; they
+    drive the OSError branch via mocking, which makes them valid
+    regression tests on every CI runner including Windows.
+    """
+
+    def test_user_chooses_copy(
+        self,
+        patched_worktree_env,
+        fail_only_claudechic,
+        reset_symlink_fallback_to_ask,
+    ):
+        """E2E: OSError on .claudechic + callback returns 'copy'.
+
+        Pins the full copy-fallback contract:
+        - .claude symlinks fine (partial-failure / per-source semantics).
+        - Callback is invoked exactly once (sticky decision, even though
+          .claude is attempted first and succeeds).
+        - .claudechic in the new worktree is a real directory, not a
+          symlink, and contains the source's contents.
+        - Edits to the source AFTER creation do NOT appear in the copy
+          (snapshot semantics; pins the user-visible difference vs.
+          symlinks so silent fallback can't sneak back in).
+        """
+        main_wt = patched_worktree_env["main_wt"]
+        new_wt = patched_worktree_env["new_wt"]
+        (main_wt / ".claude").mkdir()
+        (main_wt / ".claude" / "settings.json").write_text("{}\n")
+        (main_wt / ".claudechic").mkdir()
+        (main_wt / ".claudechic" / "before.yaml").write_text("v: 1\n")
+
+        prompted: list[str] = []
+
+        def cb(name: str, _err: OSError) -> str:
+            prompted.append(name)
+            return "copy"
+
+        success, _, wt_path = start_worktree("feat-x", cb)
+
+        assert success
+        assert wt_path == new_wt
+        # Prompt-once contract: only the failing source asked the user.
+        assert prompted == [".claudechic"]
+        # .claude succeeded as a real symlink.
+        assert (new_wt / ".claude").is_symlink()
+        # .claudechic was copied -- real dir, not a symlink, contents match.
+        assert (new_wt / ".claudechic").is_dir()
+        assert not (new_wt / ".claudechic").is_symlink()
+        assert (new_wt / ".claudechic" / "before.yaml").read_text() == "v: 1\n"
+
+        # Snapshot semantics: edit source AFTER creation; copy must not see it.
+        (main_wt / ".claudechic" / "after.yaml").write_text("v: 2\n")
+        assert not (new_wt / ".claudechic" / "after.yaml").exists()
+
+    def test_user_chooses_abort(
+        self,
+        patched_worktree_env,
+        fail_all_symlinks,
+        reset_symlink_fallback_to_ask,
+    ):
+        """E2E: OSError + callback returns 'abort' rolls back the worktree.
+
+        ``start_worktree`` returns failure and the worktree directory is
+        cleaned up via ``_rollback_worktree`` (best-effort
+        ``git worktree remove --force`` + ``rmtree``).
+        """
+        main_wt = patched_worktree_env["main_wt"]
+        new_wt = patched_worktree_env["new_wt"]
+        (main_wt / ".claudechic").mkdir()
+
+        success, msg, wt_path = start_worktree("feat-x", lambda _n, _e: "abort")
+
+        assert not success
+        assert wt_path is None
+        assert "abort" in msg.lower()
+        assert not new_wt.exists()
+
+    def test_no_consent_channel_aborts_safely(
+        self,
+        patched_worktree_env,
+        fail_all_symlinks,
+        reset_symlink_fallback_to_ask,
+    ):
+        """E2E: OSError + no callback + default 'ask' policy = safe abort.
+
+        Pins the security-relevant invariant: when no consent channel is
+        wired up, we never silently copy. The user must explicitly
+        approve the snapshot fallback for it to happen.
+        """
+        main_wt = patched_worktree_env["main_wt"]
+        new_wt = patched_worktree_env["new_wt"]
+        (main_wt / ".claudechic").mkdir()
+
+        # No callback. Default config policy is "ask" (set by fixture).
+        success, msg, _ = start_worktree("feat-x")
+
+        assert not success
+        assert "abort" in msg.lower()
+        assert not new_wt.exists()


### PR DESCRIPTION
## Summary

- When `.claude/` / `.claudechic/` cannot be symlinked into a new worktree (Windows w/o Developer Mode, FAT32, network shares, etc.), prompt the user to **copy** the source as a snapshot or **abort** worktree creation. Never silently degrade.
- New user-tier config: `worktree.symlink_fallback` (`"ask" | "copy" | "abort"`, default `"ask"`) lets users pre-set the policy and skip the prompt.
- POSIX happy path is unchanged; fallback only runs when `Path.symlink_to` raises a non-`FileExistsError` `OSError`.

Closes #26.

## Why prompt instead of silent copy

Copy and symlink behave differently once the source changes -- a copy is a one-time snapshot, while a symlink stays live. Silently falling back to copy on Windows would give a Windows user a worktree whose `.claudechic/` state mysteriously stops tracking edits to the main worktree. The prompt makes the semantic difference explicit.

`Escape` on the prompt defaults to `"abort"` -- dismissal can never imply consent. Same for the no-callback / `"ask"` config combo (e.g., headless tooling): defensive abort, never silent copy.

## Files

- `claudechic/config.py` -- `worktree.symlink_fallback` schema + `get_symlink_fallback()` validator (invalid value -> warn + fall back to `"ask"`).
- `claudechic/features/worktree/git.py` -- `_propagate_state_sync` with callback-driven copy/abort fallback + `_rollback_worktree` (best-effort `git worktree remove --force` + `rmtree`).
- `claudechic/widgets/prompts.py` -- new `SymlinkFallbackPrompt` (two options: copy / abort; failing dir name + `OSError` text in subtitle).
- `claudechic/features/worktree/commands.py` -- `_switch_or_create_worktree` is now `@work async`; bridges sync `start_worktree` to the async prompt via `asyncio.run_coroutine_threadsafe`.
- `docs/configuration.md` -- new `worktree.symlink_fallback` section.

## Tests

Three E2E tests cover the three behavioral outcomes:

- `test_user_chooses_copy` -- callback returns `"copy"` -> partial-failure case (`.claude` symlinks fine, `.claudechic` copies); copy is a real dir not a symlink; snapshot semantics (later edits to source do NOT propagate -- pins the user-visible difference vs. symlinks).
- `test_user_chooses_abort` -- callback returns `"abort"` -> rollback removes worktree, `start_worktree` returns failure.
- `test_no_consent_channel_aborts_safely` -- no callback + default `"ask"` policy -> defensive abort. Pins the security-relevant invariant.

Plus 1 parametrized config test (6 valid-value cases + 1 invalid) and 1 parametrized widget test (4 input -> resolution paths). All run cross-platform via mocked `OSError`, so coverage of the Windows code path doesn't require a Windows runner.

The pre-existing `TestWorktreeSymlinkPropagation` (POSIX happy-path) tests are unchanged; their `_unix_only` skip reason was updated to no longer point at #26.

## Test plan

- [x] `pytest tests/test_worktree_symlink.py tests/test_worktree_config.py tests/test_config.py tests/test_widgets.py --timeout=30` -- 105 passed.
- [x] Full suite: `pytest tests/ -n auto -q --timeout=30` -- only pre-existing `test_app_ui.py` parallel-load flakes (unrelated to this change; pass in isolation).
- [x] `ruff check` clean. `ruff format` applied. `pyright` 0 errors on changed files.
- [ ] Manual smoke test on Linux (POSIX happy path) -- reviewer.
- [ ] Manual smoke test on Windows w/ Developer Mode off (fallback path) -- if a Windows user is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)