### PR TITLE
feat(mcp): add broadcast_message tool for sending to multiple agents

### DIFF
--- a/claudechic/context/CLAUDE.md
+++ b/claudechic/context/CLAUDE.md
@@ -42,11 +42,13 @@ The status footer shows per-agent state:
 ## Inter-Agent Communication (MCP Tools)
 
 - **`message_agent`** -- Send a message to another agent. By default expects a reply (target is nudged if idle without responding). Set `requires_answer=false` for fire-and-forget messages (status updates, results, answering questions).
+- **`broadcast_message`** -- Send the same message to a list of agents at once. Same `requires_answer` semantics as `message_agent`. Per-target failures (missing agent, etc.) are reported in the result without aborting the broadcast; the caller's own name is silently skipped.
 - **`interrupt_agent`** -- Interrupt an agent's current task immediately. Optionally redirect with a new prompt. Use when you need to stop or redirect a busy agent in real-time.
 
 **When to use which:**
-- Need a response? Use `message_agent` (default: `requires_answer=true`).
-- Sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
+- One target, need a response? Use `message_agent` (default: `requires_answer=true`).
+- One target, sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
+- Multiple targets, same message? Use `broadcast_message` (with `requires_answer=true` if you expect each to reply, `false` for FYI-style updates).
 - Need to stop/redirect NOW? Use `interrupt_agent` (cuts through immediately).
 
 ## Agent Self-Awareness (MCP Tools)

--- a/claudechic/context/multi-agent-architecture.md
+++ b/claudechic/context/multi-agent-architecture.md
@@ -96,11 +96,13 @@ Async callback: `(agent, request) -> "allow" | "deny" | "allow_all"`.
 ## Inter-Agent Communication (MCP Tools)
 
 - **`message_agent`** -- Send a message to another agent. By default expects a reply (target is nudged if idle without responding). Set `requires_answer=false` for fire-and-forget messages (status updates, results, answering questions).
+- **`broadcast_message`** -- Send the same message to a list of agents at once. Same `requires_answer` semantics as `message_agent`. Per-target failures are reported in the result without aborting the broadcast; the caller's own name is silently skipped.
 - **`interrupt_agent`** -- Interrupt an agent's current task immediately. Optionally redirect with a new prompt. Use when you need to stop or redirect a busy agent in real-time.
 
 **When to use which:**
-- Need a response? Use `message_agent` (default: `requires_answer=true`).
-- Sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
+- One target, need a response? Use `message_agent` (default: `requires_answer=true`).
+- One target, sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
+- Multiple targets, same message? Use `broadcast_message` (with `requires_answer=true` if you expect each to reply, `false` for FYI-style updates).
 - Need to stop/redirect NOW? Use `interrupt_agent` (cuts through immediately).
 
 ## Commands

--- a/claudechic/mcp.py
+++ b/claudechic/mcp.py
@@ -452,6 +452,120 @@ def _make_message_agent(caller_name: str | None = None):
     return message_agent
 
 
+def _make_broadcast_message(caller_name: str | None = None):
+    """Create broadcast_message tool with optional caller name bound.
+
+    Sends the same message to multiple agents at once. Built on top of the
+    same fire-and-forget delivery as ``message_agent`` -- per-target failures
+    (e.g. agent not found) do not abort the broadcast; the result aggregates
+    a per-target status line so the caller can see exactly who got it.
+    """
+
+    @tool(
+        "broadcast_message",
+        (
+            "Send the same message to multiple agents at once. Like "
+            "message_agent but takes a list of names. Per-target failures "
+            "(missing agent, etc.) are reported in the result without "
+            "aborting the broadcast. The caller is silently skipped if "
+            "included in the list (broadcasting to yourself is a noop)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": (
+                        "Names of the target agents. Duplicates are deduped; "
+                        "the caller's own name (if present) is skipped."
+                    ),
+                },
+                "message": {"type": "string"},
+                "requires_answer": {
+                    "type": "boolean",
+                    "description": (
+                        "If true (default), each target is expected to "
+                        "reply. Set to false for fire-and-forget broadcasts "
+                        "(status updates, results)."
+                    ),
+                },
+            },
+            "required": ["names", "message"],
+        },
+    )
+    async def broadcast_message(args: dict[str, Any]) -> dict[str, Any]:
+        """Broadcast a message to multiple agents. Non-blocking per target."""
+        if _app is None or _app.agent_mgr is None:
+            return _error_response("App not initialized")
+        _track_mcp_tool("broadcast_message")
+
+        raw_names = args["names"]
+        message = args["message"]
+        requires_answer = args.get("requires_answer", True)
+
+        # Tolerate accidental string-instead-of-list passing. JSON Schema
+        # marks names as an array, but defensive coercion keeps a stray
+        # ``"alice"`` from blowing up the broadcast.
+        if isinstance(raw_names, str):
+            raw_names = [raw_names]
+        if not isinstance(raw_names, list) or not raw_names:
+            return _error_response("'names' must be a non-empty list of agent names")
+
+        # Dedupe while preserving order (so the result rows match the
+        # caller's intent), then drop the caller's own name. We do NOT
+        # short-circuit on an empty post-filter list with isError -- this
+        # is a noop, not a failure.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for raw in raw_names:
+            if not isinstance(raw, str):
+                continue
+            n = raw.strip()
+            if not n or n in seen:
+                continue
+            seen.add(n)
+            ordered.append(n)
+
+        results: list[tuple[str, str]] = []  # (name, status)
+        delivered = 0
+        for n in ordered:
+            if caller_name is not None and n == caller_name:
+                results.append((n, "skipped (self)"))
+                continue
+            agent, error = _find_agent_by_name(n)
+            if agent is None:
+                results.append((n, error or "not found"))
+                continue
+            _send_prompt_fire_and_forget(
+                agent, message, caller_name=caller_name, expect_reply=requires_answer
+            )
+            if not requires_answer:
+                # Same fire-and-forget reply-clearing semantics as
+                # message_agent: if the caller had an outstanding question
+                # to this target, satisfying any one delivery clears it.
+                _clear_pending_reply_if_matched(caller_name, n)
+            results.append((n, "sent"))
+            delivered += 1
+
+        preview = message[:80] + "..." if len(message) > 80 else message
+        header = f"Broadcast ({delivered}/{len(ordered)} delivered): {preview}"
+        body_lines = [f"  - {n}: {status}" for n, status in results]
+        text = "\n".join([header, *body_lines])
+
+        # If nothing was delivered (e.g. every name missing), surface as
+        # an error so the caller treats it as a failure rather than a
+        # silent noop. A self-only broadcast counts as "no error" because
+        # it's a noop the caller authored intentionally.
+        all_missing = delivered == 0 and any(
+            status not in ("skipped (self)",) for _, status in results
+        )
+        return _text_response(text, is_error=all_missing)
+
+    return broadcast_message
+
+
 def _make_whoami(caller_name: str | None = None):
     """Create whoami tool that returns this agent's name."""
 
@@ -1731,6 +1845,7 @@ def create_chic_server(
         _make_spawn_agent(caller_name),
         _make_spawn_worktree(caller_name),
         _make_message_agent(caller_name),
+        _make_broadcast_message(caller_name),
         _make_whoami(caller_name),
         list_agents,
         _make_close_agent(caller_name),

--- a/tests/test_mcp_message_agent.py
+++ b/tests/test_mcp_message_agent.py
@@ -3,7 +3,7 @@
 import asyncio
 
 import pytest
-from claudechic.mcp import _make_message_agent, set_app
+from claudechic.mcp import _make_broadcast_message, _make_message_agent, set_app
 
 
 class MockAgent:
@@ -16,6 +16,12 @@ class MockAgent:
         self.worktree = None
         self.client = True  # truthy
         self.received_prompt = None
+        # Reply-tracking state used by mcp._clear_pending_reply_if_matched.
+        # broadcast_message touches these on requires_answer=False; mocking
+        # them here keeps the test honest without pulling in the real Agent.
+        self._pending_reply_to: str | None = None
+        self._reply_nudge_count = 0
+        self._nudge_generation = 0
 
     @property
     def analytics_id(self) -> str:
@@ -117,3 +123,140 @@ async def test_message_agent_nonexistent_returns_error(mock_app):
     assert result["isError"] is True
     assert "ghost" in result["content"][0]["text"]
     assert "not found" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# broadcast_message: send same message to a list of agents at once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broadcast_message_delivers_to_all_targets(mock_app):
+    """Each target in the list receives the same wrapped prompt."""
+    alice = MockAgent("alice")
+    bob = MockAgent("bob")
+    carol = MockAgent("carol")
+    mock_app.agent_mgr.add(alice)
+    mock_app.agent_mgr.add(bob)
+    mock_app.agent_mgr.add(carol)
+
+    broadcast = _make_broadcast_message(caller_name="alice")
+
+    result = await broadcast.handler(
+        {"names": ["bob", "carol"], "message": "Standup at 10?"}
+    )
+    await asyncio.sleep(0)  # drain fire-and-forget tasks
+
+    assert result.get("isError") is not True
+    text = result["content"][0]["text"]
+    assert "2/2 delivered" in text
+    assert "bob: sent" in text
+    assert "carol: sent" in text
+
+    # Both targets see the same sender-injected prompt body.
+    for target in (bob, carol):
+        assert target.received_prompt is not None
+        assert "[Question from agent 'alice'" in target.received_prompt
+        assert "Standup at 10?" in target.received_prompt
+
+
+@pytest.mark.asyncio
+async def test_broadcast_message_partial_failure_reports_per_target(mock_app):
+    """Missing targets are reported in the result; valid ones still get sent.
+
+    The broadcast is NOT aborted by a single missing name -- partial
+    delivery is the explicit contract so a typo in one of N names doesn't
+    silently drop the other N-1.
+    """
+    alice = MockAgent("alice")
+    bob = MockAgent("bob")
+    mock_app.agent_mgr.add(alice)
+    mock_app.agent_mgr.add(bob)
+
+    broadcast = _make_broadcast_message(caller_name="alice")
+
+    result = await broadcast.handler({"names": ["bob", "ghost"], "message": "ping"})
+    await asyncio.sleep(0)
+
+    assert result.get("isError") is not True  # at least one delivered
+    text = result["content"][0]["text"]
+    assert "1/2 delivered" in text
+    assert "bob: sent" in text
+    assert "ghost:" in text and "not found" in text
+    assert bob.received_prompt is not None  # bob got it
+
+
+@pytest.mark.asyncio
+async def test_broadcast_message_all_missing_is_error(mock_app):
+    """If every target is missing, the broadcast is reported as an error."""
+    alice = MockAgent("alice")
+    mock_app.agent_mgr.add(alice)
+
+    broadcast = _make_broadcast_message(caller_name="alice")
+
+    result = await broadcast.handler(
+        {"names": ["ghost1", "ghost2"], "message": "anyone?"}
+    )
+
+    assert result["isError"] is True
+    text = result["content"][0]["text"]
+    assert "0/2 delivered" in text
+
+
+@pytest.mark.asyncio
+async def test_broadcast_message_skips_self_and_dedupes(mock_app):
+    """Caller's own name is skipped; duplicates collapse to a single delivery.
+
+    Skipping self pins the documented "broadcasting to yourself is a
+    noop" contract. Dedupe pins the "caller intent: send once per
+    distinct name" contract.
+    """
+    alice = MockAgent("alice")
+    bob = MockAgent("bob")
+    mock_app.agent_mgr.add(alice)
+    mock_app.agent_mgr.add(bob)
+
+    broadcast = _make_broadcast_message(caller_name="alice")
+
+    # alice broadcasts to herself + bob (twice). Expected: only bob receives,
+    # exactly once. Self is reported as "skipped (self)".
+    result = await broadcast.handler(
+        {"names": ["alice", "bob", "bob"], "message": "ping"}
+    )
+    await asyncio.sleep(0)
+
+    text = result["content"][0]["text"]
+    assert "1/2 delivered" in text  # post-dedupe: 2 unique (alice, bob); 1 sent
+    assert "alice: skipped (self)" in text
+    assert "bob: sent" in text
+    # Bob's prompt should appear only once -- not concatenated from a duplicate.
+    assert bob.received_prompt is not None
+    assert bob.received_prompt.count("ping") == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_message_fire_and_forget_uses_tell_framing(mock_app):
+    """``requires_answer=false`` propagates the no-reply framing to each target."""
+    alice = MockAgent("alice")
+    bob = MockAgent("bob")
+    carol = MockAgent("carol")
+    mock_app.agent_mgr.add(alice)
+    mock_app.agent_mgr.add(bob)
+    mock_app.agent_mgr.add(carol)
+
+    broadcast = _make_broadcast_message(caller_name="alice")
+
+    await broadcast.handler(
+        {
+            "names": ["bob", "carol"],
+            "message": "FYI: rebased main",
+            "requires_answer": False,
+        }
+    )
+    await asyncio.sleep(0)
+
+    for target in (bob, carol):
+        assert target.received_prompt is not None
+        # Fire-and-forget framing: "Message from" prefix, no reply instruction.
+        assert "[Message from agent 'alice'" in target.received_prompt
+        assert "respond using message_agent" not in target.received_prompt


### PR DESCRIPTION
## Summary

New MCP tool ``broadcast_message`` -- sibling to ``message_agent``, takes a list of agent names and sends the same prompt to each.

```jsonc
{
  "names": ["bob", "carol"],
  "message": "Standup at 10?",
  "requires_answer": true   // default true; same semantics as message_agent
}
```

Result example:

```
Broadcast (1/2 delivered): ping
  - bob: sent
  - ghost: Agent 'ghost' not found. Use list_agents to see available agents.
```

## Design choices

- **Separate tool, not an overload of ``message_agent``** -- different signature (list vs string), different return shape (per-target aggregation), different semantic (one-to-many). A separate verb is clearer to the agent calling it and avoids regressing the existing `message_agent` contract.
- **Partial-success contract** -- a missing target reports a per-row error and continues; the broadcast as a whole only reports `isError=True` when zero targets were delivered. Pins the "typo in one of N names doesn't silently drop the other N-1" intent.
- **Skip self silently** -- broadcasting to yourself is a noop (the target is your own SDK connection -- sending to yourself just creates loops). Listed in the result as `skipped (self)`.
- **Dedupe in input order** -- duplicate names collapse to a single delivery; preserves the caller's intended display order in the per-target result rows.
- **Same fire-and-forget framing as ``message_agent``** -- ``[Question from agent 'X' ...]`` with ``requires_answer=true``, ``[Message from agent 'X']`` with ``requires_answer=false``. Reply-clearing semantics (`_clear_pending_reply_if_matched`) apply per-target.

## Files

- `claudechic/mcp.py` -- new `_make_broadcast_message(caller_name)` factory + register in `create_chic_server`.
- `claudechic/context/CLAUDE.md` -- added to the inter-agent communication quick-reference (auto-installed as `~/.claude/rules/claudechic_CLAUDE.md`).
- `claudechic/context/multi-agent-architecture.md` -- same update in the architecture rule (also auto-installed).
- `tests/test_mcp_message_agent.py` -- 5 new tests (delivery, partial failure, all-missing-is-error, self+dedupe, fire-and-forget framing). Plus a small `MockAgent` extension for the reply-tracking attributes.

## Test plan

- [x] `pytest tests/test_mcp_message_agent.py --timeout=30` -- 8 passed (3 existing, 5 new).
- [x] `pytest tests/ -n auto -q --timeout=30 -k "mcp or message"` -- 49 passed.
- [x] `ruff check`, `ruff format`, `pyright` -- all clean.
- [ ] Reviewer: smoke-test with two real agents in a live claudechic session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)