### PR TITLE
feat(models): add Opus 4.8 to default extra model entries

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -137,6 +137,12 @@ TOOL_USE_ERROR_PATTERN = re.compile(r"</?tool_use_error>")
 # adding `models: {extra: [...]}` to ~/.claude/.claudechic.yaml.
 DEFAULT_EXTRA_MODEL_ENTRIES: list[dict] = [
     # ── Opus ────────────────────────────────────────────────────────
+    {"value": "claude-opus-4-8", "displayName": "Opus 4.8", "description": "Opus 4.8"},
+    {
+        "value": "claude-opus-4-8[1m]",
+        "displayName": "Opus 4.8 (1M)",
+        "description": "Opus 4.8 (1M context)",
+    },
     {"value": "claude-opus-4-7", "displayName": "Opus 4.7", "description": "Opus 4.7"},
     {
         "value": "claude-opus-4-7[1m]",

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -44,6 +44,8 @@ def test_merge_appends_default_extras():
     assert "claude-opus-4-6[1m]" in values
     assert "claude-opus-4-7" in values
     assert "claude-opus-4-7[1m]" in values
+    assert "claude-opus-4-8" in values
+    assert "claude-opus-4-8[1m]" in values
     assert "claude-sonnet-4-6[1m]" in values
 
 


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-8` and `claude-opus-4-8[1m]` to `DEFAULT_EXTRA_MODEL_ENTRIES` in `claudechic/app.py` so the model picker surfaces Opus 4.8 alongside 4.5/4.6/4.7.
- Extends `tests/test_model_selection.py::test_merge_appends_default_extras` to assert both new IDs are merged in.

## Motivation
Without an entry in this list, Opus 4.8 is invisible in the model picker even though the CLI happily routes the full ID via `--model`. Plain Claude Code picks 4.8 up dynamically because it asks `get_server_info()` at runtime; claudechic relies on this static merge layer, so each new model has to be added by hand (same pattern as 4.5 -> 4.6 -> 4.7).

## Test plan
- [x] End-to-end: applied the equivalent change via the `models.extra` YAML override on a real claudechic install, restarted, picked Opus 4.8 from the `/model` picker, and confirmed a message round-trips against `claude-opus-4-8`.
- [x] Direct CLI sanity check: `claude --print --model claude-opus-4-8 "..."` returns a clean response on the same account.
- [x] `_merge_model_extras` smoke-tested in a fresh Python process - both new IDs end up in the merged list with the SDK entries preserved at the front.
- [ ] `pytest tests/test_model_selection.py` (CI should cover; not run locally to avoid touching the host pixi env).

No behavior changes for any other model.