### PR TITLE
fix: deliver Monitor/task notifications while idle; stop double-Escape killing sessions

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -249,7 +249,7 @@ class Agent:
         self._pending_reply_to: str | None = None  # Agent name we owe a reply to
         self._reply_nudge_count: int = 0  # How many nudges sent for current obligation
         self._nudge_generation: int = 0  # Monotonic counter to deduplicate nudge timers
-        self.model: str | None = "opus"  # Model override (None = SDK default)
+        self.model: str | None = "claude-opus-4-8[1m]"  # Model override (None = SDK default)
         # SDK thinking-budget level. Plumbed into ClaudeAgentOptions(effort=...)
         # via _make_options. "max" is Opus-only; non-Opus models snap to
         # "medium" on model change. Read live by the options factory.

--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -151,6 +151,10 @@ class ResponseContext:
     text_buffer: str = ""
     needs_new_message: bool = True
     had_tools: bool = False
+    # True for CLI-initiated turns consumed by the idle listener (e.g.
+    # Monitor wake-ups / background task notifications). Enables rendering
+    # of injected user text and assistant-envelope text fallback.
+    unsolicited: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +232,19 @@ class Agent:
             False  # Drain leftover SDK messages after interrupt
         )
 
+        # Idle-time stream listener: consumes CLI-initiated turns (Monitor
+        # wake-ups, background task notifications) that arrive between
+        # client-initiated responses. Enabled by connect(), disabled by
+        # disconnect(). Without it those messages pile up unseen in the
+        # SDK's in-memory buffer and desync the next response.
+        self._idle_listener_task: asyncio.Task[None] | None = None
+        self._idle_listener_enabled: bool = False
+
+        # Re-entrancy guard for interrupt() (double-Escape protection).
+        # A second concurrent interrupt() escalated to a SIGINT that killed
+        # the CLI process; see interrupt() for details.
+        self._interrupting: bool = False
+
         # Chat history
         self.messages: list[ChatItem] = []
 
@@ -249,7 +266,9 @@ class Agent:
         self._pending_reply_to: str | None = None  # Agent name we owe a reply to
         self._reply_nudge_count: int = 0  # How many nudges sent for current obligation
         self._nudge_generation: int = 0  # Monotonic counter to deduplicate nudge timers
-        self.model: str | None = "claude-opus-4-8[1m]"  # Model override (None = SDK default)
+        self.model: str | None = (
+            "claude-opus-4-8[1m]"  # Model override (None = SDK default)
+        )
         # SDK thinking-budget level. Plumbed into ClaudeAgentOptions(effort=...)
         # via _make_options. "max" is Opus-only; non-Opus models snap to
         # "medium" on model change. Read live by the options factory.
@@ -283,6 +302,11 @@ class Agent:
     def response_had_tools(self) -> bool:
         """Whether the current/last response included any tool uses."""
         return self._response.had_tools
+
+    @property
+    def is_interrupting(self) -> bool:
+        """Whether an interrupt() call is currently in flight."""
+        return self._interrupting
 
     @property
     def _current_assistant(self) -> AssistantContent | None:
@@ -347,8 +371,15 @@ class Agent:
         self.file_index = FileIndex(root=self.cwd)
         await self.file_index.refresh()
 
+        # Listen for CLI-initiated turns (Monitor wake-ups, background task
+        # notifications) that arrive while no response is in flight.
+        self._idle_listener_enabled = True
+        self._start_idle_listener()
+
     async def disconnect(self) -> None:
         """Disconnect and cleanup."""
+        self._idle_listener_enabled = False
+        await self._stop_idle_listener()
         self._pending_messages.clear()
         if self._response.task and not self._response.task.done():
             self._response.task.cancel()
@@ -551,6 +582,12 @@ class Agent:
 
         self._set_status(AgentStatus.BUSY)
 
+        # Begin cancelling the idle listener so only _process_response reads
+        # the SDK stream (the cancellation is awaited in _process_response
+        # before it starts receiving).
+        if self._idle_listener_task and not self._idle_listener_task.done():
+            self._idle_listener_task.cancel()
+
         # Reset per-response state
         self._response = ResponseContext()
         self._set_response_state(ResponseState.STREAMING)
@@ -567,6 +604,21 @@ class Agent:
         Order: SDK interrupt first (breaks the stream), then wait up to 3s
         for the task to complete naturally.  Only cancel + SIGINT as last resort.
         """
+        # Re-entrancy guard: a second interrupt (e.g. double-Escape) while
+        # one is already in flight used to run concurrently, time out on the
+        # already-broken stream, and escalate to a SIGINT that killed the
+        # CLI process (and with it the session).  Ignore it instead.
+        if self._interrupting:
+            log.info("Agent '%s': interrupt already in flight, ignoring", self.name)
+            return
+        self._interrupting = True
+        try:
+            await self._interrupt_inner()
+        finally:
+            self._interrupting = False
+
+    async def _interrupt_inner(self) -> None:
+        """Body of interrupt(); guarded against re-entry by interrupt()."""
         log.info(
             "Agent '%s': interrupt() started (state=%s)",
             self.name,
@@ -578,9 +630,11 @@ class Agent:
         # messages will be drained after the interrupt completes (see below).
         # Interrupt SDK first — breaks the stream so the task can unblock.
         # 5s timeout prevents hanging if the CLI doesn't acknowledge.
+        sdk_acked = False
         if self.client:
             try:
                 await asyncio.wait_for(self.client.interrupt(), timeout=5.0)
+                sdk_acked = True
             except asyncio.TimeoutError:
                 log.warning(
                     "Agent '%s': SDK interrupt timed out (5s), sending SIGINT",
@@ -591,18 +645,30 @@ class Agent:
                 pass
         # Wait for the response task to finish naturally.  The SDK interrupt
         # above should break the stream, causing the task to complete on its
-        # own.  Only escalate to cancel + SIGINT if it's truly stuck.
+        # own.  Only cancel (and, if the CLI never acknowledged, SIGINT) if
+        # it's truly stuck.
         if self._response.task and not self._response.task.done():
             try:
                 await asyncio.wait_for(asyncio.shield(self._response.task), timeout=3.0)
             except asyncio.TimeoutError:
-                # Task didn't finish after 3s — force cancel + SIGINT
-                log.warning(
-                    "Agent '%s': task didn't finish after interrupt (3s), sending SIGINT",
-                    self.name,
-                )
                 self._response.task.cancel()
-                self._sigint_fallback()
+                if sdk_acked:
+                    # The CLI acknowledged the interrupt — the local task is
+                    # just slow to unwind.  Cancelling it is enough; a SIGINT
+                    # here would kill the (responsive) CLI process and lose
+                    # the session.
+                    log.warning(
+                        "Agent '%s': task didn't finish after acked interrupt "
+                        "(3s), cancelled locally",
+                        self.name,
+                    )
+                else:
+                    log.warning(
+                        "Agent '%s': task didn't finish after unacked interrupt "
+                        "(3s), sending SIGINT",
+                        self.name,
+                    )
+                    self._sigint_fallback()
             except asyncio.CancelledError:
                 pass  # Task was cancelled elsewhere, that's fine
 
@@ -638,6 +704,11 @@ class Agent:
             create_safe_task(
                 _yield_then_drain(), name=f"drain-after-interrupt-{self.name}"
             )
+
+        # Resume listening for CLI-initiated turns (also consumes the
+        # leftover messages the CLI emits while winding down the aborted
+        # response). No-op if a drain above starts a new response first.
+        self._start_idle_listener()
 
         log.info("Agent '%s': interrupt() completed", self.name)
 
@@ -716,6 +787,12 @@ class Agent:
         if not self._pending_messages:
             return
 
+        # A response is already in flight (e.g. another drain path won the
+        # race, or a CLI-initiated turn started).  Keep messages queued;
+        # they are drained again when that response completes.
+        if self._response_state != ResponseState.IDLE:
+            return
+
         # If the CLI process has exited, trigger reconnection instead of
         # trying to write to a dead process.  Messages stay queued and will
         # be drained after reconnection completes.
@@ -751,6 +828,133 @@ class Agent:
             )
             if self.observer:
                 self.observer.on_connection_lost(self)
+
+    # -----------------------------------------------------------------------
+    # Idle-time stream listener (CLI-initiated turns)
+    # -----------------------------------------------------------------------
+
+    def _start_idle_listener(self) -> None:
+        """Start the idle-time SDK stream listener if not already running.
+
+        The Claude CLI can initiate turns on its own while no client request
+        is in flight — e.g. when a Monitor tool fires or a background task
+        completes, the CLI injects a task-notification user message and
+        streams a full assistant turn.  Without a reader those messages pile
+        up unseen in the SDK's in-memory buffer, desync the next
+        receive_response() call (its ResultMessage terminates the iterator
+        early), and stall the SDK's read loop entirely once 100 messages
+        accumulate.  The listener consumes and renders them as they arrive.
+        """
+        if not self._idle_listener_enabled or not self.client:
+            return
+        if self._idle_listener_task and not self._idle_listener_task.done():
+            return
+        self._idle_listener_task = asyncio.create_task(
+            self._idle_listener(), name=f"agent-{self.id}-idle-listener"
+        )
+
+    async def _stop_idle_listener(self) -> None:
+        """Cancel the idle listener and wait for it to finish.
+
+        Must complete before _process_response starts reading so the two
+        never compete for messages on the SDK stream.
+
+        Note: anyio memory streams can drop a single message if the receiver
+        is cancelled at the exact instant of delivery. The window is a few
+        microseconds around a user-initiated send; worst case one CLI
+        notification is not displayed (it remains in the session transcript).
+        """
+        task = self._idle_listener_task
+        if task is None:
+            return
+        self._idle_listener_task = None
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def _idle_listener(self) -> None:
+        """Consume SDK messages while no client-initiated response runs."""
+        try:
+            while True:
+                client = self.client
+                if client is None:
+                    return
+                turn_started = False
+                got_message = False
+                had_tool_use: dict[str | None, bool] = {}
+                async for message in client.receive_response():
+                    got_message = True
+                    if (
+                        not turn_started
+                        and self._response_state == ResponseState.IDLE
+                        and isinstance(
+                            message, (UserMessage, AssistantMessage, StreamEvent)
+                        )
+                    ):
+                        # Content while idle means the CLI started a turn on
+                        # its own (Monitor / background task notification).
+                        # SystemMessages (init, thinking_tokens, ...) and
+                        # leftover ResultMessages don't open a turn.
+                        turn_started = True
+                        self._begin_unsolicited_turn()
+                    await self._handle_sdk_message(message, had_tool_use)
+                if turn_started:
+                    self._end_unsolicited_turn()
+                if not got_message:
+                    # Iterator ended without yielding anything: the stream
+                    # is closed (CLI process exited or client shut down).
+                    log.warning("Agent '%s': idle listener stream closed", self.name)
+                    if not self._is_transport_alive() and self.observer:
+                        self.observer.on_connection_lost(self)
+                    return
+        except asyncio.CancelledError:
+            raise
+        except CLIConnectionError:
+            log.info("Agent '%s': idle listener disconnected", self.name)
+        except Exception:
+            log.exception("Agent '%s': idle listener failed", self.name)
+
+    def _begin_unsolicited_turn(self) -> None:
+        """Mark the start of a CLI-initiated turn (Monitor/task notification)."""
+        log.info("Agent '%s': CLI-initiated turn started", self.name)
+        self._response = ResponseContext(unsolicited=True)
+        self._set_status(AgentStatus.BUSY)
+        self._set_response_state(ResponseState.STREAMING)
+
+    def _end_unsolicited_turn(self) -> None:
+        """Finish a CLI-initiated turn: reset state, drain queued messages."""
+        self._flush_current_text()
+        log.info("Agent '%s': CLI-initiated turn completed", self.name)
+        self._set_response_state(ResponseState.IDLE)
+        self._set_status(AgentStatus.IDLE)
+        # Drain messages queued while the CLI-initiated turn was streaming
+        # (same pattern as the _process_response finally block).
+        if self._pending_messages:
+
+            async def _yield_then_drain() -> None:
+                await asyncio.sleep(0)  # let ResponseComplete propagate
+                self._drain_next_message()
+
+            create_safe_task(_yield_then_drain(), name="drain-pending-message")
+
+    def _render_injected_user_text(self, text: str) -> None:
+        """Record and display a CLI-injected user message.
+
+        Used for the task-notification text the CLI injects when a Monitor
+        tool fires or a background task completes.
+        """
+        self.messages.append(
+            ChatItem(
+                role="user",
+                content=UserContent(text=text),
+                metadata=MessageMetadata(
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+        )
+        if self.observer:
+            self.observer.on_prompt_sent(self, text, [])
 
     # -----------------------------------------------------------------------
     # Response processing
@@ -792,6 +996,11 @@ Key Rules:
     async def _process_response(self, prompt: str) -> None:
         """Process SDK response stream."""
         try:
+            # Ensure the idle listener is fully stopped before reading so
+            # the two never compete for messages on the SDK stream
+            # (_start_response already initiated the cancellation).
+            await self._stop_idle_listener()
+
             # Prepend plan mode instructions if in plan mode
             if self.permission_mode == "plan":
                 prompt = self._get_plan_mode_instructions() + prompt
@@ -895,6 +1104,9 @@ Key Rules:
                         self._drain_next_message()
 
                     create_safe_task(_yield_then_drain(), name="drain-pending-message")
+                # Resume listening for CLI-initiated turns while idle.
+                # (When interrupted, interrupt() restarts the listener.)
+                self._start_idle_listener()
 
     # Process liveness check interval (seconds)
     _LIVENESS_CHECK_INTERVAL = 30
@@ -997,6 +1209,12 @@ Key Rules:
                     had_tool_use[parent_id] = True
                 elif isinstance(block, ToolResultBlock):
                     self._handle_tool_result(block)
+                elif isinstance(block, SDKTextBlock) and self._response.unsolicited:
+                    # CLI-initiated turns may not stream partial events; if
+                    # no streamed text accumulated, fall back to the
+                    # envelope text so the turn isn't rendered empty.
+                    if block.text and not self._current_text_buffer:
+                        self._handle_text_chunk(block.text, True, parent_id)
 
         elif isinstance(message, UserMessage):
             # Capture UUID for checkpoints (needed for /rewind file restoration)
@@ -1013,12 +1231,17 @@ Key Rules:
             # deliver that envelope on receive_response.)
             content = getattr(message, "content", "")
             if isinstance(content, str):
+                if content and self._response.unsolicited:
+                    # CLI-injected user text (Monitor / task notification)
+                    self._render_injected_user_text(content)
                 self._scan_user_text_for_commands(content)
             elif isinstance(content, list):
                 for block in content:
                     if isinstance(block, ToolResultBlock):
                         self._handle_tool_result(block)
                     elif isinstance(block, SDKTextBlock):
+                        if block.text and self._response.unsolicited:
+                            self._render_injected_user_text(block.text)
                         self._scan_user_text_for_commands(block.text)
 
         elif isinstance(message, StreamEvent):

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -445,6 +445,7 @@ class ChatApp(App):
         self._hamburger_btn: HamburgerButton | None = None
         # Available models from SDK (populated in _update_slash_commands)
         self._available_models: list[dict] = []
+        self._fast_mode: bool = False
         # Track pending slash commands passed to Claude (for typo detection)
         # agent_id -> command name (e.g., "/cleanup")
         self._pending_slash_commands: dict[str, str] = {}
@@ -1266,6 +1267,7 @@ class ChatApp(App):
             permission_mode=permission_mode,
             env=env,
             setting_sources=["user", "project", "local"],
+            settings=str(self._FAST_MODE_SETTINGS) if self._fast_mode else None,
             cwd=cwd,
             resume=resume,
             model=model,
@@ -1277,6 +1279,49 @@ class ChatApp(App):
             enable_file_checkpointing=True,
             extra_args={"replay-user-messages": None},
         )
+
+    _FAST_MODE_SETTINGS = Path(__file__).parent / "fast_mode_settings.json"
+
+    async def _handle_fast_command(self, arg: str) -> None:
+        """Toggle fast mode on/off. Reconnects the active agent."""
+        arg = arg.strip().lower()
+        if arg == "on":
+            if self._fast_mode:
+                self.notify("Fast mode is already on.")
+                return
+            self._fast_mode = True
+            self.notify("Fast mode: on (2.5x speed, extra cost)")
+            await self._reconnect_for_fast_mode()
+        elif arg == "off":
+            if not self._fast_mode:
+                self.notify("Fast mode is already off.")
+                return
+            self._fast_mode = False
+            self.notify("Fast mode: off")
+            await self._reconnect_for_fast_mode()
+        elif arg == "":
+            state = "on" if self._fast_mode else "off"
+            self.notify(f"Fast mode: {state}")
+        else:
+            self.notify("Usage: /fast on | /fast off", severity="error")
+
+    async def _reconnect_for_fast_mode(self) -> None:
+        """Reconnect the active agent so the CLI re-reads settings."""
+        agent = self._agent
+        if not agent or not agent.client:
+            return
+        try:
+            session_id = agent.session_id
+            await agent.disconnect()
+            options = self._make_options(
+                cwd=agent.cwd,
+                resume=session_id,
+                agent_name=agent.name,
+                model=agent.model,
+            )
+            await agent.connect(options, resume=session_id)
+        except Exception as e:
+            self.show_error("Fast mode reconnect failed", e)
 
     async def on_mount(self) -> None:
         # Track app start (and install if new user)

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -1273,6 +1273,7 @@ class ChatApp(App):
             resume=resume,
             model=model,
             effort=effort_level,
+            cli_path=self._resolve_cli_path(),
             mcp_servers={"chic": create_chic_server(caller_name=agent_name)},
             include_partial_messages=True,
             stderr=self._handle_sdk_stderr,
@@ -1282,6 +1283,35 @@ class ChatApp(App):
         )
 
     _FAST_MODE_SETTINGS = Path(__file__).parent / "fast_mode_settings.json"
+
+    # Candidate locations for a newer `claude` CLI than the one bundled inside
+    # the claude-agent-sdk package. The SDK's bundled binary (currently 2.1.92)
+    # only allows fast mode (`{"fastMode": true}` -> usage.speed == "fast") for
+    # opus-4-6; newer CLIs (>= ~2.1.191) extend eligibility to opus-4-8. The
+    # CLAUDECHIC_CLI_PATH env var takes precedence; otherwise we probe known
+    # on-disk locations. If none exist we return None so the SDK falls back to
+    # its bundled binary (no behavior change).
+    _CLI_PATH_CANDIDATES = (
+        Path.home() / ".local" / "bin" / "claude.exe",
+        Path.home() / ".local" / "bin" / "claude",
+    )
+
+    @classmethod
+    def _resolve_cli_path(cls) -> str | None:
+        """Return a path to a newer `claude` CLI if one is available, else None.
+
+        Lets fast mode work on opus-4-8 by avoiding the older CLI bundled in the
+        claude-agent-sdk package. Returns None (SDK uses its bundle) when no
+        override binary is found, so the change is a no-op on machines without
+        an updated CLI installed.
+        """
+        override = os.environ.get("CLAUDECHIC_CLI_PATH")
+        if override and Path(override).exists():
+            return override
+        for candidate in cls._CLI_PATH_CANDIDATES:
+            if candidate.exists():
+                return str(candidate)
+        return None
 
     async def _handle_fast_command(self, arg: str) -> None:
         """Toggle fast mode on/off. Reconnects the active agent."""

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -4090,6 +4090,12 @@ class ChatApp(App):
         # Interrupt running agent via Agent.interrupt() (handles SDK interrupt,
         # SIGINT fallback, on_complete, and state cleanup).
         if self._agent and self._agent.status == "busy":
+            # Debounce: a second Escape while an interrupt is in flight used
+            # to spawn a concurrent interrupt() that escalated to a SIGINT
+            # and killed the CLI process (closing the session).
+            if self._agent.is_interrupting:
+                self.notify("Interrupt already in progress")
+                return
             self.run_worker(
                 self._agent.interrupt(),
                 exclusive=False,

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -137,6 +137,7 @@ TOOL_USE_ERROR_PATTERN = re.compile(r"</?tool_use_error>")
 # adding `models: {extra: [...]}` to ~/.claude/.claudechic.yaml.
 DEFAULT_EXTRA_MODEL_ENTRIES: list[dict] = [
     # ── Opus ────────────────────────────────────────────────────────
+    {"value": "claude-opus-4-8", "displayName": "Opus 4.8", "description": "Opus 4.8"},
     {"value": "claude-opus-4-7", "displayName": "Opus 4.7", "description": "Opus 4.7"},
     {
         "value": "claude-opus-4-7[1m]",

--- a/claudechic/commands.py
+++ b/claudechic/commands.py
@@ -106,6 +106,7 @@ COMMANDS: list[tuple[str, str, list[str]]] = [
     ("/compactish", "Compact session to reduce context", []),
     ("/usage", "Show API rate limit usage", []),
     ("/model", "Change model", []),
+    ("/fast", "Toggle fast mode (extra cost)", ["/fast on", "/fast off"]),
     ("/vim", "Toggle vi mode for input", []),
     ("/processes", "Show background processes", []),
     ("/reviews", "Show roborev reviews", []),
@@ -278,6 +279,12 @@ def handle_command(app: ChatApp, prompt: str) -> bool:
     if cmd == "/usage":
         _track_command(app, "usage")
         app._handle_usage_command()
+        return True
+
+    if cmd == "/fast" or cmd.startswith("/fast "):
+        _track_command(app, "fast")
+        arg = cmd.split(maxsplit=1)[1] if " " in cmd else ""
+        app.run_worker(app._handle_fast_command(arg), exclusive=False, exit_on_error=False)
         return True
 
     if cmd == "/model" or cmd.startswith("/model "):

--- a/claudechic/fast_mode_settings.json
+++ b/claudechic/fast_mode_settings.json
@@ -1,0 +1,1 @@
+{"fastMode": true}

--- a/tests/test_idle_listener.py
+++ b/tests/test_idle_listener.py
@@ -1,0 +1,228 @@
+"""Tests for the idle-time SDK stream listener (CLI-initiated turns).
+
+Covers the Monitor / background-task notification delivery path: the CLI
+can start a turn on its own while no client request is in flight (e.g. a
+Monitor tool fires). The idle listener must consume the turn, render the
+injected user text and assistant reply, reset agent state, and drain any
+messages queued meanwhile. See Agent._idle_listener.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, UserMessage
+from claude_agent_sdk import TextBlock as SDKTextBlock
+
+from claudechic.agent import Agent
+from claudechic.enums import AgentStatus, ResponseState
+
+pytestmark = pytest.mark.asyncio
+
+
+def _result_message(**overrides) -> ResultMessage:
+    defaults = dict(
+        subtype="success",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-1",
+    )
+    defaults.update(overrides)
+    return ResultMessage(**defaults)
+
+
+async def _wait_until(predicate, timeout: float = 2.0) -> None:
+    """Poll predicate until true (or fail the test after timeout)."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            pytest.fail("condition not reached within timeout")
+        await asyncio.sleep(0.01)
+
+
+@pytest.fixture
+def make_agent_with_scripted_stream(tmp_path):
+    """Build an Agent whose mock client serves scripted receive_response turns.
+
+    ``turns`` is a list of message lists; each receive_response() call pops
+    and yields one turn. Once exhausted, further calls block forever
+    (simulating an open stream with no traffic).
+    """
+
+    def _make(turns: list[list]) -> Agent:
+        agent = Agent(name="idle-test", cwd=tmp_path)
+        client = MagicMock()
+        remaining = list(turns)
+
+        def receive_response():
+            async def _gen():
+                if not remaining:
+                    await asyncio.sleep(3600)  # open stream, no traffic
+                    return
+                for msg in remaining.pop(0):
+                    yield msg
+
+            return _gen()
+
+        client.receive_response = receive_response
+        client.query = AsyncMock()
+        client.interrupt = AsyncMock()
+        # Expose the script so tests can append turns (e.g. when query() is
+        # called, mirroring the CLI only responding after a prompt is sent).
+        client._script = remaining
+        # Make _is_transport_alive() report a live subprocess
+        client._query.transport._process.pid = 12345
+        client._query.transport._process.returncode = None
+        agent.client = client
+        agent._idle_listener_enabled = True
+        return agent
+
+    return _make
+
+
+class TestIdleListenerDelivery:
+    """CLI-initiated turns are consumed and rendered while idle."""
+
+    async def test_delivers_cli_initiated_turn(self, make_agent_with_scripted_stream):
+        turn = [
+            UserMessage(
+                content=(
+                    "<task-notification>Monitor fired: CI is green</task-notification>"
+                )
+            ),
+            AssistantMessage(
+                content=[SDKTextBlock(text="CI is green, proceeding.")],
+                model="claude-test",
+            ),
+            _result_message(),
+        ]
+        agent = make_agent_with_scripted_stream([turn])
+        observer = MagicMock()
+        agent.observer = observer
+
+        agent._start_idle_listener()
+        await _wait_until(lambda: observer.on_complete.called)
+
+        # Injected user notification recorded in history and shown in UI
+        user_items = [m for m in agent.messages if m.role == "user"]
+        assert any("Monitor fired" in m.content.text for m in user_items)
+        observer.on_prompt_sent.assert_called_once()
+
+        # Assistant reply rendered (envelope-text fallback path)
+        assistant_items = [m for m in agent.messages if m.role == "assistant"]
+        assert assistant_items
+        assert "CI is green" in assistant_items[-1].content.blocks[-1].text
+
+        # Turn completion propagated and state reset
+        observer.on_complete.assert_called_once()
+        await _wait_until(lambda: agent.status == AgentStatus.IDLE)
+        assert agent._response_state == ResponseState.IDLE
+
+        await agent._stop_idle_listener()
+
+    async def test_agent_busy_while_cli_turn_streams(
+        self, make_agent_with_scripted_stream
+    ):
+        """Status goes BUSY for the CLI-initiated turn, then back to IDLE."""
+        turn = [
+            UserMessage(content="notification"),
+            _result_message(),
+        ]
+        agent = make_agent_with_scripted_stream([turn])
+
+        # Intercept status transitions to observe BUSY during the turn
+        seen_status: list[AgentStatus] = []
+        original = agent._set_status
+
+        def _spy(status):
+            seen_status.append(status)
+            original(status)
+
+        agent._set_status = _spy  # type: ignore[method-assign]
+
+        agent._start_idle_listener()
+        await _wait_until(lambda: AgentStatus.BUSY in seen_status)
+        await _wait_until(lambda: agent.status == AgentStatus.IDLE)
+        assert agent._response_state == ResponseState.IDLE
+
+        await agent._stop_idle_listener()
+
+    async def test_queued_message_drained_after_cli_turn(
+        self, make_agent_with_scripted_stream
+    ):
+        """Messages queued during a CLI-initiated turn are sent afterwards."""
+        turn = [UserMessage(content="notification"), _result_message()]
+        agent = make_agent_with_scripted_stream([turn])
+
+        # The CLI only produces the response turn after query() is sent
+        # (otherwise the idle listener could consume it prematurely).
+        async def _on_query(prompt, session_id="default"):
+            agent.client._script.append([_result_message(session_id="sess-2")])
+
+        agent.client.query = AsyncMock(side_effect=_on_query)
+
+        agent._pending_messages.append(("queued prompt", None))
+
+        agent._start_idle_listener()
+        await _wait_until(lambda: agent.client.query.await_count == 1)
+        agent.client.query.assert_awaited_once_with("queued prompt")
+        await _wait_until(lambda: agent._response_state == ResponseState.IDLE)
+        assert agent._pending_messages == []
+
+        await agent._stop_idle_listener()
+        task = agent._response.task
+        if task and not task.done():
+            task.cancel()
+
+
+class TestIdleListenerLifecycle:
+    """Listener starts/stops around client-initiated responses."""
+
+    async def test_start_response_stops_listener(self, make_agent_with_scripted_stream):
+        agent = make_agent_with_scripted_stream([])  # stream open, no traffic
+        agent._start_idle_listener()
+        listener = agent._idle_listener_task
+        assert listener is not None
+        await asyncio.sleep(0)  # let listener enter receive_response
+
+        await agent.send("hello")
+        await _wait_until(lambda: listener.done())
+        assert agent._idle_listener_task is None
+        assert agent.client.query.await_count == 1
+
+        # Cleanup the (blocked) response task
+        task = agent._response.task
+        assert task is not None
+        task.cancel()
+        import contextlib
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def test_listener_noop_when_disabled(self, tmp_path):
+        agent = Agent(name="idle-test", cwd=tmp_path)
+        agent.client = MagicMock()
+        # _idle_listener_enabled defaults to False (set by connect())
+        agent._start_idle_listener()
+        assert agent._idle_listener_task is None
+
+    async def test_listener_exits_on_closed_stream(
+        self, make_agent_with_scripted_stream
+    ):
+        """An empty receive_response (closed stream) exits without spinning."""
+        agent = make_agent_with_scripted_stream([[]])  # one empty iteration
+        # Dead transport -> listener should report connection lost and exit
+        agent.client._query.transport._process.returncode = 1
+        observer = MagicMock()
+        agent.observer = observer
+
+        agent._start_idle_listener()
+        listener = agent._idle_listener_task
+        assert listener is not None
+        await _wait_until(lambda: listener.done())
+        observer.on_connection_lost.assert_called_once()

--- a/tests/test_interrupt_agent_integration.py
+++ b/tests/test_interrupt_agent_integration.py
@@ -291,7 +291,12 @@ class TestTimeoutFallback:
     async def test_interrupt_task_timeout_triggers_cancel(
         self, real_agent_with_mock_sdk
     ):
-        """Test 2.7: Response task not finishing within 3s gets cancelled + SIGINT."""
+        """Test 2.7: Stuck task after ACKED interrupt gets cancelled, NO SIGINT.
+
+        The CLI acknowledged the interrupt, so it is responsive; a SIGINT
+        here would kill the CLI process and lose the session (double-Escape
+        bug). Only the local response task is cancelled.
+        """
         agent, _mock_client = real_agent_with_mock_sdk
 
         # SDK interrupt returns immediately, but response task never finishes
@@ -311,10 +316,85 @@ class TestTimeoutFallback:
             await asyncio.sleep(0)
             assert stuck_task.done()
             assert stuck_task.cancelled()
-            # SIGINT fallback should have been called
+            # SDK interrupt was acknowledged -> SIGINT must NOT be sent
+            sigint_spy.assert_not_called()
+
+        assert agent.status == AgentStatus.IDLE
+        assert agent._response_state == ResponseState.IDLE
+
+    @pytest.mark.slow
+    async def test_interrupt_unacked_task_timeout_triggers_sigint(
+        self, real_agent_with_mock_sdk
+    ):
+        """Stuck task after FAILED (unacked) SDK interrupt still gets SIGINT."""
+        agent, mock_client = real_agent_with_mock_sdk
+
+        async def _fail():
+            raise RuntimeError("control channel broken")
+
+        mock_client.interrupt = _fail
+
+        agent._set_response_state(ResponseState.STREAMING)
+        agent._set_status(AgentStatus.BUSY)
+
+        async def _never_finish():
+            await asyncio.sleep(3600)
+
+        stuck_task = asyncio.create_task(_never_finish(), name="stuck-response")
+        agent._response = ResponseContext(task=stuck_task)
+
+        with patch.object(agent, "_sigint_fallback") as sigint_spy:
+            await agent.interrupt()
+            await asyncio.sleep(0)
+            assert stuck_task.cancelled()
+            # No ack from the CLI -> SIGINT is the last resort
             sigint_spy.assert_called_once()
 
         assert agent.status == AgentStatus.IDLE
+        assert agent._response_state == ResponseState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Re-entrancy guard (double-Escape protection)
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptReentrancy:
+    """A second interrupt() while one is in flight must be a no-op."""
+
+    async def test_concurrent_interrupt_is_ignored(self, real_agent_with_mock_sdk):
+        """Second interrupt() returns immediately; SDK interrupt called once."""
+        agent, mock_client = real_agent_with_mock_sdk
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def _slow_interrupt():
+            nonlocal calls
+            calls += 1
+            started.set()
+            await release.wait()
+
+        mock_client.interrupt = _slow_interrupt
+
+        # Streaming state with no response task (skips the 3s task wait so
+        # the test stays fast; re-entrancy is about the SDK call anyway).
+        agent._set_response_state(ResponseState.STREAMING)
+        agent._set_status(AgentStatus.BUSY)
+        agent._response = ResponseContext()
+
+        first = asyncio.create_task(agent.interrupt())
+        await started.wait()
+        assert agent.is_interrupting
+
+        # Second interrupt while the first is blocked in the SDK call
+        await agent.interrupt()  # must return without touching the SDK
+        assert calls == 1
+
+        release.set()
+        await first
+        assert not agent.is_interrupting
         assert agent._response_state == ResponseState.IDLE
 
 
@@ -520,11 +600,18 @@ class TestDrainRace:
             # Let all background tasks run (drain + fire-and-forget)
             await asyncio.sleep(0.1)
 
-        # Both the queued message and redirect should have been delivered
-        # The queued message is drained by _yield_then_drain from interrupt()
-        # The redirect is sent by fire-and-forget
-        assert len(delivered_prompts) >= 1
-        # At minimum, the drain task should have picked up the queued message
+            # The redirect was delivered
+            assert "redirect prompt" in delivered_prompts
+
+            # The queued message must not be LOST.  With the drain guard
+            # (no concurrent responses on one SDK stream), delivery may be
+            # deferred while the redirect's response is in flight; it is
+            # drained when that response completes -- simulated here.
+            if "queued message from earlier" not in delivered_prompts:
+                agent._set_response_state(ResponseState.IDLE)
+                agent._set_status(AgentStatus.IDLE)
+                agent._drain_next_message()
+
         assert "queued message from earlier" in delivered_prompts
 
         await _cancel_task(task)


### PR DESCRIPTION
## Summary

Fixes two coupled bugs, plus carries the pending Opus 4.8 / fast-mode commits from `sprustonlab-main`:

**1. Monitor wake-ups and background-task notifications were never delivered.** The SDK stream was only read inside `_process_response`, so turns the CLI initiates on its own (Monitor firing, task notifications) piled up unseen in the SDK's in-memory buffer, desynced the next `receive_response()` call, and were discarded by the post-interrupt stale-drain. Now a persistent idle-time listener consumes and renders CLI-initiated turns between client-initiated responses (starts on connect/after each response/after interrupt; stops before every send so two readers never share the stream; detects a dead CLI while idle and reconnects).

**2. Hitting Escape twice closed the agent session.** A second concurrent `interrupt()` timed out on the already-broken stream and escalated to a SIGINT that killed the headless CLI process. Fixed by re-entry-guarding `interrupt()` (`Agent.is_interrupting`), debouncing Escape in `action_escape`, and only sending SIGINT when the CLI never acknowledged the SDK interrupt.

## Testing

- New `tests/test_idle_listener.py` (6 tests) covering turn delivery, busy-state, queued-message drain, listener lifecycle, closed-stream exit
- Updated interrupt integration tests: acked interrupt cancels locally (no SIGINT), unacked interrupt still SIGINTs, concurrent interrupt is a no-op, drain-race message deferred-not-lost
- Full suite: 941 passed (one pre-existing xdist flake in `test_checks_tier_aware`, unrelated)
- Verified live via the remote harness: a `sleep 25` background probe's completion notification renders in chat after the turn ended; double-Escape during a streaming response leaves the session alive with zero SIGINTs logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)