### PR TITLE
feat(agents): don't send acknowledgement-only replies between agents

### DIFF
--- a/claudechic/context/CLAUDE.md
+++ b/claudechic/context/CLAUDE.md
@@ -50,6 +50,7 @@ The status footer shows per-agent state:
 - One target, sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
 - Multiple targets, same message? Use `broadcast_message` (with `requires_answer=true` if you expect each to reply, `false` for FYI-style updates).
 - Need to stop/redirect NOW? Use `interrupt_agent` (cuts through immediately).
+- Received an FYI / status / result and have nothing substantive to add? Do NOT reply -- acknowledgement-only messages ("thanks", "good job", "got it") are needless traffic. Stay silent unless you have an answer, result, or decision.
 
 ## Agent Self-Awareness (MCP Tools)
 

--- a/claudechic/context/multi-agent-architecture.md
+++ b/claudechic/context/multi-agent-architecture.md
@@ -104,6 +104,7 @@ Async callback: `(agent, request) -> "allow" | "deny" | "allow_all"`.
 - One target, sending info, no reply needed? Use `message_agent` with `requires_answer=false`.
 - Multiple targets, same message? Use `broadcast_message` (with `requires_answer=true` if you expect each to reply, `false` for FYI-style updates).
 - Need to stop/redirect NOW? Use `interrupt_agent` (cuts through immediately).
+- Received an FYI / status / result and have nothing substantive to add? Do NOT reply -- acknowledgement-only messages ("thanks", "good job", "got it") are needless traffic. Stay silent unless you have an answer, result, or decision.
 
 ## Commands
 

--- a/claudechic/defaults/environment/base.md
+++ b/claudechic/defaults/environment/base.md
@@ -12,3 +12,7 @@ ${PEER_ROSTER}
 ## Tools
 
 `message_agent` for tasks and questions (recipient expected to reply); `message_agent` with `requires_answer=false` for status updates and answers. `interrupt_agent` to halt or redirect a busy peer. Call `mcp__chic__get_agent_info` for a full snapshot: your identity, current phase, and applicable rules in one document.
+
+## Replying to peers
+
+Reply to a peer only when your reply carries substance -- an answer, a result, a decision, or a follow-up question. Do NOT send acknowledgement-only messages ("thanks", "good job", "got it", "sounds good"): they create needless inter-agent traffic without moving work forward. If an incoming message needs no action and no answer from you, end your turn without replying. A peer who sent `requires_answer=false` (a status update, a result, an FYI) is signalling that no reply is expected -- stay silent unless you genuinely have something to add.


### PR DESCRIPTION
## Why
Agents were replying "thanks" / "good job" / "got it" to fire-and-forget messages, creating **needless inter-agent traffic** (and idle nudges) without moving work forward. This receiver-side etiquette instruction was lost and is re-added here.

## What
A **receiver-side** rule: reply to a peer only when the reply carries substance (an answer, result, decision, or follow-up question). If a message needs no action and no answer, end the turn without replying. A `requires_answer=false` message signals no reply is expected.

## Changes (3 files, +6)
- **`defaults/environment/base.md`** -- new **"Replying to peers"** section in the environment every agent receives (the operative change).
- **`context/CLAUDE.md`** and **`context/multi-agent-architecture.md`** -- matching bullet in the "When to use which" list, so the docs stay consistent (and `context/CLAUDE.md` installs as a Claude rule).

Complements the existing sender-side `requires_answer=false` guidance and the nudge system -- this is the other half (the receiver knowing when *not* to reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)