### PR TITLE
feat(models): capability-driven effort levels; document legacy model pins

### DIFF
--- a/claudechic/agent.py
+++ b/claudechic/agent.py
@@ -276,9 +276,10 @@ class Agent:
             "claude-opus-4-8[1m]"  # Model override (None = SDK default)
         )
         # SDK thinking-budget level. Plumbed into ClaudeAgentOptions(effort=...)
-        # via _make_options. "max" is Opus-only; non-Opus models snap to
-        # "medium" on model change. Read live by the options factory.
-        self.effort: Literal["low", "medium", "high", "max"] = "high"
+        # via _make_options. Levels the model doesn't support (per the
+        # CLI-advertised capabilities) snap to "medium" on model change.
+        # Read live by the options factory.
+        self.effort: Literal["low", "medium", "high", "xhigh", "max"] = "high"
 
         # Worktree finish state (for /worktree finish flow)
         self.finish_state: FinishState | None = None

--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -119,6 +119,7 @@ from claudechic.widgets import (
 from claudechic.widgets.layout.footer import (
     AgentLabel,
     DiagnosticsLabel,
+    EffortLabel,
     ModelLabel,
     PermissionModeLabel,
     SettingsLabel,
@@ -133,12 +134,20 @@ _PKG_DIR = Path(__file__).parent
 # Pattern to strip SDK's <tool_use_error> tags from error messages
 TOOL_USE_ERROR_PATTERN = re.compile(r"</?tool_use_error>")
 
-# Full-ID model entries merged into the SDK's curated model menu so the user
-# can target specific versions (e.g. Opus 4.6) that the CLI no longer
-# advertises in `get_server_info()["models"]`. The CLI still routes full IDs
-# via `--model`, so these values can be passed straight through. Override by
-# adding `models: {extra: [...]}` to ~/.claude/.claudechic.yaml.
-DEFAULT_EXTRA_MODEL_ENTRIES: list[dict] = [
+# Legacy version pins: full-ID model entries merged into the SDK's curated
+# model menu so the user can still target versions (e.g. Opus 4.6) that the
+# CLI no longer advertises in `get_server_info()["models"]`. The CLI still
+# routes full IDs via `--model`, so these values pass straight through.
+#
+# POLICY: never add a newly released model here. New models appear in the
+# picker automatically via `get_server_info()` as soon as the installed
+# Claude Code CLI knows about them -- this list exists only for the legacy
+# tail. Add an entry only when the CLI *drops* a model from its curated menu
+# and users still want to pin it. Users can extend the list without a
+# claudechic release by adding `models: {extra: [...]}` to
+# ~/.claudechic/config.yaml; extra entries may also declare
+# `supportedEffortLevels` to feed the effort picker.
+LEGACY_MODEL_PINS: list[dict] = [
     # ── Opus ────────────────────────────────────────────────────────
     {"value": "claude-opus-4-8", "displayName": "Opus 4.8", "description": "Opus 4.8"},
     {"value": "claude-opus-4-7", "displayName": "Opus 4.7", "description": "Opus 4.7"},
@@ -186,10 +195,10 @@ def _merge_model_extras(
 
     Deduplicates by ``value``; SDK entries win on collision. Entries without
     a ``value`` key are skipped. A ``None`` ``extras`` arg uses the built-in
-    ``DEFAULT_EXTRA_MODEL_ENTRIES`` list.
+    ``LEGACY_MODEL_PINS`` list.
     """
     if extras is None:
-        extras = DEFAULT_EXTRA_MODEL_ENTRIES
+        extras = LEGACY_MODEL_PINS
     seen = {m.get("value") for m in sdk_models if m.get("value")}
     merged = list(sdk_models)
     for m in extras:
@@ -1311,8 +1320,9 @@ class ChatApp(App):
         without a live Agent reference.
 
         Per SPEC §C1: ``agent.effort`` is read live and forwarded to the
-        SDK as ``ClaudeAgentOptions(effort=...)``. ``"max"`` is Opus-only;
-        non-Opus models snap on the widget side via slot 5.
+        SDK as ``ClaudeAgentOptions(effort=...)``. Levels a model doesn't
+        support (per the CLI-advertised capabilities, e.g. ``"max"`` on
+        Haiku) snap on the widget side via slot 5.
         """
         # Override ANTHROPIC_API_KEY to prefer subscription auth,
         # unless ANTHROPIC_BASE_URL is set (SSO proxy needs the key).
@@ -1803,11 +1813,15 @@ class ChatApp(App):
             if "models" in info:
                 models = info["models"]
                 if isinstance(models, list) and models:
-                    # Merge in extra full-ID entries (Opus 4.5/4.6/etc.) so the
+                    # Merge in legacy version pins (Opus 4.5/4.6/etc.) so the
                     # user can target versions the CLI no longer advertises.
-                    # User override: models.extra in ~/.claude/.claudechic.yaml.
+                    # User override: models.extra in ~/.claudechic/config.yaml.
                     extras = CONFIG.get("models", {}).get("extra")
                     self._available_models = _merge_model_extras(models, extras)
+                    # Feed advertised effort capabilities to the footer's
+                    # effort picker BEFORE the footer.model write below
+                    # triggers the snap logic in watch_model.
+                    EffortLabel.update_model_capabilities(self._available_models)
                     # Update footer with current agent's model
                     agent = self._agent
                     self._update_footer_model(agent.model if agent else None)

--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -60,8 +60,9 @@ def _load() -> tuple[dict, bool]:
         # SDK thinking-budget level (SPEC C3). Survives restart and is
         # mirrored into Agent.effort by the StatusFooter on mount + by
         # the settings re-apply path.  Valid values: low / medium / high
-        # / max ("max" is Opus-only; non-Opus models snap to "medium"
-        # via EffortLabel.set_available_levels).
+        # / xhigh / max (levels the active model doesn't support -- per
+        # the CLI-advertised capabilities -- snap to "medium" via
+        # EffortLabel.set_available_levels).
         config.setdefault("effort", "high")
         # Migrate legacy vim key to vi-mode
         if "vim" in config:

--- a/claudechic/context/CLAUDE.md
+++ b/claudechic/context/CLAUDE.md
@@ -34,7 +34,7 @@ claudechic is a terminal UI for Claude Code with multi-agent support, workflows,
 
 The status footer shows per-agent state:
 
-- **Effort** -- `effort: low | medium | high | max`. Click `EffortLabel` to cycle. `max` is Opus-only; switching to a non-Opus model snaps effort to `medium` automatically.
+- **Effort** -- `effort: low | medium | high | xhigh | max`. Click `EffortLabel` to cycle through the levels the active model supports (advertised by the Claude Code CLI). Switching to a model that doesn't support the current level snaps effort to `medium` automatically.
 - **Model** -- active model name.
 - **Permission mode** -- current tool-use permission level (Shift+Tab to cycle).
 - **Context bar** -- token usage fraction (colors: dim -> yellow -> red).

--- a/claudechic/context/multi-agent-architecture.md
+++ b/claudechic/context/multi-agent-architecture.md
@@ -24,7 +24,7 @@ The `Agent` class owns everything for a single Claude agent:
 - **UI widgets:** `chat_view`, `current_response`, `pending_tool_widgets`, `active_task_widgets`
 - **Per-agent state:** `todos`, `auto_approve_edits`, `file_index`, `pending_images`
 - **Runtime role:** `agent_type: str` (default `"default"`) -- queryable role identity. Promoted to the workflow's `main_role` on activation, reverted on deactivation, survives `/compact`.
-- **Effort:** `effort: Literal["low", "medium", "high", "max"]` -- per-agent thinking budget passed to the SDK on every `_make_options()` call. `"max"` is Opus-only; switching to a non-Opus model snaps effort to `"medium"` automatically. Displayed and cycled via the `EffortLabel` widget in the status footer.
+- **Effort:** `effort: Literal["low", "medium", "high", "xhigh", "max"]` -- per-agent thinking budget passed to the SDK on every `_make_options()` call. Valid levels per model come from the CLI-advertised capabilities (`get_server_info()` `supportedEffortLevels`), with static family fallbacks; switching to a model that doesn't support the current level snaps effort to `"medium"` automatically. Displayed and cycled via the `EffortLabel` widget in the status footer.
 
 Key methods: `connect()`, `send()`, `wait_for_completion()`, `interrupt()`.
 

--- a/claudechic/screens/settings.py
+++ b/claudechic/screens/settings.py
@@ -37,11 +37,12 @@ log = logging.getLogger(__name__)
 
 _PERMISSION_MODES = ("default", "acceptEdits", "plan", "auto", "bypassPermissions")
 _NOTIFY_LEVELS = ("debug", "info", "warning", "error", "none")
-# SDK thinking-budget levels (SPEC C3). "max" is Opus-only; we still
-# expose it in /settings so an Opus user can set the persistent default.
-# The footer EffortLabel snaps to "medium" on non-Opus models even when
-# config says "max".
-_EFFORT_LEVELS = ("low", "medium", "high", "max")
+# SDK thinking-budget levels (SPEC C3). Not every model supports the top
+# levels; we still expose all of them in /settings so a user can set the
+# persistent default for a capable model. The footer EffortLabel snaps to
+# "medium" when the active model doesn't support the configured level
+# (per the CLI-advertised capabilities).
+_EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
 
 
 @dataclass(frozen=True)

--- a/claudechic/widgets/layout/footer.py
+++ b/claudechic/widgets/layout/footer.py
@@ -114,10 +114,21 @@ class EffortLabel(ClickableLabel):
     """Clickable effort label - cycles through valid SDK ``effort`` levels.
 
     The on-screen label text uses the literal string ``"effort"`` to match
-    SDK vocabulary (per SPEC Decision 2). The level cycles
-    ``low -> medium -> high -> max -> low`` on click; ``max`` is Opus-only,
-    so non-Opus models snap the displayed level to ``"medium"`` on model
-    change (per SPEC locked Decision 5 from slot 1 review).
+    SDK vocabulary (per SPEC Decision 2). The level cycles through the
+    model's supported set on click; when the model changes, a level the
+    new model doesn't support snaps to ``"medium"`` (per SPEC locked
+    Decision 5 from slot 1 review).
+
+    Which levels a model supports comes from two sources, in order:
+
+    1. The capability registry populated from ``get_server_info()``
+       model entries (``supportedEffortLevels``) via
+       ``update_model_capabilities`` -- this tracks whatever the
+       installed Claude Code CLI actually advertises, so new models
+       and new levels need no claudechic change.
+    2. Static per-family fallbacks (``MODEL_EFFORT_LEVELS``) for model
+       strings the registry doesn't know -- legacy version pins and
+       older CLIs that don't report capability metadata.
 
     On click the widget mutates ``app._agent.effort`` directly (the
     options factory reads ``agent.effort`` live) and persists the new
@@ -128,22 +139,33 @@ class EffortLabel(ClickableLabel):
     # Global ordering used to snap a current level into a smaller subset
     # when the model changes. Members of ``_levels`` always preserve this
     # relative ordering.
-    DEFAULT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
+    DEFAULT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
-    # Per-model effort levels.  ``max`` triggers extended thinking which
-    # is only supported on Opus.
+    # Static per-family fallbacks, used only when the capability registry
+    # has no entry for the model string (legacy version pins, or a CLI old
+    # enough not to report supportedEffortLevels). Kept conservative: a
+    # level missing here is merely un-offered, while an unsupported level
+    # sent to the SDK errors.
     MODEL_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
         "haiku": ("low", "medium", "high"),
         "sonnet": ("low", "medium", "high"),
         "opus": ("low", "medium", "high", "max"),
+        "fable": ("low", "medium", "high", "xhigh", "max"),
     }
 
     EFFORT_DISPLAY: dict[str, str] = {
         "low": "effort: low",
         "medium": "effort: medium",
         "high": "effort: high",
+        "xhigh": "effort: xhigh",
         "max": "effort: max",
     }
+
+    # Capability registry: lowercase model keys -> advertised effort levels.
+    # Populated by ``update_model_capabilities`` from the SDK's model list;
+    # class-level so ``levels_for_model`` stays a classmethod usable from
+    # any footer instance.
+    _capability_levels: dict[str, tuple[str, ...]] = {}
 
     class Cycled(Message):
         """Emitted after the user clicks to cycle effort level.
@@ -241,23 +263,58 @@ class EffortLabel(ClickableLabel):
         self.set_effort(best)
 
     # Fallback for unknown model strings: the safer subset without
-    # ``"max"`` (which is Opus-only and rejected by other families).
+    # the top levels, which not every family supports.
     UNKNOWN_MODEL_LEVELS: tuple[str, ...] = ("low", "medium", "high")
+
+    @classmethod
+    def update_model_capabilities(cls, models: list[dict]) -> None:
+        """Rebuild the capability registry from SDK model entries.
+
+        ``models`` is the list from ``get_server_info()["models"]``
+        (possibly merged with legacy pins). Entries that carry a
+        non-empty ``supportedEffortLevels`` list are registered under
+        every name the rest of the app might later hand to
+        ``levels_for_model``: the routable ``value``, the
+        ``displayName``, and the short name the footer extracts from
+        ``description`` (the text before the first ``·``). Entries
+        without capability metadata (e.g. legacy pins) are skipped and
+        keep resolving through the static family fallbacks.
+        """
+        registry: dict[str, tuple[str, ...]] = {}
+        for m in models:
+            levels = m.get("supportedEffortLevels")
+            if (
+                not isinstance(levels, list)
+                or not levels
+                or not all(isinstance(lvl, str) for lvl in levels)
+            ):
+                continue
+            desc = m.get("description")
+            short_name = (
+                desc.split("·")[0] if isinstance(desc, str) and "·" in desc else None
+            )
+            for key in (m.get("value"), m.get("displayName"), short_name):
+                if isinstance(key, str) and key.strip():
+                    registry.setdefault(key.strip().lower(), tuple(levels))
+        cls._capability_levels = registry
 
     @classmethod
     def levels_for_model(cls, model: str | None) -> tuple[str, ...]:
         """Return the valid effort levels for a model string.
 
-        Matches against known model families by checking if ``model``
-        contains a known alias (``opus`` / ``sonnet`` / ``haiku``).
-        Unknown model strings (or empty) fall back to
-        ``UNKNOWN_MODEL_LEVELS`` -- the safer subset without ``"max"``,
-        since ``"max"`` is Opus-only and would be rejected by any
-        non-Opus family the alias-match missed.
+        Consults the capability registry first (exact, case-insensitive
+        match on what the CLI advertised). Otherwise matches against
+        known model families by checking if ``model`` contains a known
+        alias (``opus`` / ``sonnet`` / ``haiku`` / ``fable``). Unknown
+        model strings (or empty) fall back to ``UNKNOWN_MODEL_LEVELS``
+        -- the safer subset, since offering an unsupported level would
+        send a rejected value to the SDK.
         """
         if not model:
             return cls.UNKNOWN_MODEL_LEVELS
-        model_lower = model.lower()
+        model_lower = model.strip().lower()
+        if model_lower in cls._capability_levels:
+            return cls._capability_levels[model_lower]
         for family, levels in cls.MODEL_EFFORT_LEVELS.items():
             if family in model_lower:
                 return levels

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,6 +255,47 @@ environment_segment:
     sites: [spawn, activation, post-compact]
 ```
 
+### `effort`
+
+- **Type:** `str` -- one of `low` / `medium` / `high` / `xhigh` / `max`
+- **Default:** `high`
+- **Exposed in `/settings`:** yes (label: "Effort")
+
+Persistent default for the SDK thinking-budget level. Mirrored into each
+agent's `effort` on startup and cycled at runtime by clicking the footer's
+`EffortLabel`. The levels offered per model come from the capabilities the
+Claude Code CLI advertises (`get_server_info()` `supportedEffortLevels`);
+if the active model does not support the configured level, the footer
+snaps it to `medium`.
+
+```yaml
+effort: high
+```
+
+### `models.extra`
+
+- **Type:** `list[dict]` -- entries shaped like the SDK's model list
+- **Default:** unset (falls back to the built-in legacy pins)
+- **Exposed in `/settings`:** no
+
+Extra model entries appended to the `/model` picker. The picker is
+populated dynamically from `get_server_info()` -- newly released models
+appear automatically once the installed Claude Code CLI knows about them,
+so this override is only needed to pin **older** full-ID versions that the
+CLI no longer advertises (the built-in default list covers common ones,
+e.g. Opus 4.5/4.6/4.7). Entries are deduplicated by `value`; SDK entries
+win on collision. An entry may also declare `supportedEffortLevels` to
+feed the footer's effort picker.
+
+```yaml
+models:
+  extra:
+    - value: claude-opus-4-6
+      displayName: Opus 4.6
+      description: Opus 4.6
+      supportedEffortLevels: [low, medium, high, max]
+```
+
 ### `experimental.*`
 
 - **Type:** mixed

--- a/tests/test_effort_cycling.py
+++ b/tests/test_effort_cycling.py
@@ -103,10 +103,10 @@ class _FooterTestApp(App):
 async def test_c2_clicking_effort_label_cycles_visible_text(tmp_path: Path) -> None:
     """Gestalt user-side: clicking the label cycles through locked strings.
 
-    The cycle order is the locked contract from SPEC C2 / Decision 5:
-    ``low -> medium -> high -> max -> low``. The on-screen text is the
-    locked-string ``"effort: <level>"`` (lower-case, no punctuation),
-    matching SDK vocabulary.
+    The cycle order is the locked global ordering from SPEC C2 /
+    Decision 5: ``low -> medium -> high -> xhigh -> max -> low``. The
+    on-screen text is the locked-string ``"effort: <level>"``
+    (lower-case, no punctuation), matching SDK vocabulary.
 
     Persisting the cycled level to ``~/.claudechic/config.yaml`` would
     leak across test runs; we patch ``config.save`` to a no-op and only
@@ -120,7 +120,7 @@ async def test_c2_clicking_effort_label_cycles_visible_text(tmp_path: Path) -> N
             label = footer.query_one("#effort-label", EffortLabel)
             await pilot.pause()
 
-            # Reset to a known starting level + force the full 4-level
+            # Reset to a known starting level + force the full level
             # set so the test does not depend on what hydrate-from-config
             # produced on mount or which model the footer's reactive
             # picked. The full cycle is the locked contract per SPEC C2.
@@ -132,6 +132,7 @@ async def test_c2_clicking_effort_label_cycles_visible_text(tmp_path: Path) -> N
             expected_cycle = [
                 "effort: medium",
                 "effort: high",
+                "effort: xhigh",
                 "effort: max",
                 "effort: low",
             ]
@@ -151,22 +152,30 @@ async def test_c2_clicking_effort_label_cycles_visible_text(tmp_path: Path) -> N
 
 
 def test_c2_effort_label_display_strings_are_locked() -> None:
-    """SPEC's locked contract strings: exactly four ``"effort: <level>"``."""
+    """SPEC's locked contract strings: ``"effort: <level>"`` per level."""
     assert EffortLabel.EFFORT_DISPLAY["low"] == "effort: low"
     assert EffortLabel.EFFORT_DISPLAY["medium"] == "effort: medium"
     assert EffortLabel.EFFORT_DISPLAY["high"] == "effort: high"
+    assert EffortLabel.EFFORT_DISPLAY["xhigh"] == "effort: xhigh"
     assert EffortLabel.EFFORT_DISPLAY["max"] == "effort: max"
 
 
 def test_c2_effort_label_default_levels_order() -> None:
     """Cycle order is the locked global ordering."""
-    assert EffortLabel.DEFAULT_LEVELS == ("low", "medium", "high", "max")
+    assert EffortLabel.DEFAULT_LEVELS == ("low", "medium", "high", "xhigh", "max")
 
 
 def test_c2_effort_label_levels_for_opus_includes_max() -> None:
-    """Opus is the only family that supports ``"max"``."""
+    """The Opus family fallback supports ``"max"``."""
     assert "max" in EffortLabel.levels_for_model("claude-opus-4")
     assert "max" in EffortLabel.levels_for_model("opus")
+
+
+def test_c2_effort_label_levels_for_fable_includes_top_levels() -> None:
+    """The Fable family fallback supports ``"xhigh"`` and ``"max"``."""
+    levels = EffortLabel.levels_for_model("claude-fable-5[1m]")
+    assert "xhigh" in levels
+    assert "max" in levels
 
 
 @pytest.mark.parametrize(
@@ -276,7 +285,7 @@ def test_c3_settings_screen_registers_effort_key() -> None:
     """C3: the settings registry exposes ``effort`` as a user-tier enum.
 
     SPEC §C3 mandates that the ``effort`` key be visible in the settings
-    screen with the four valid levels as its enum choices.
+    screen with the valid levels as its enum choices.
     """
     from claudechic.screens.settings import USER_KEYS
 
@@ -284,7 +293,7 @@ def test_c3_settings_screen_registers_effort_key() -> None:
     assert spec is not None, "USER_KEYS must include the 'effort' key"
     assert spec.tier == "user"
     assert spec.editor == "enum"
-    assert tuple(spec.choices) == ("low", "medium", "high", "max")
+    assert tuple(spec.choices) == ("low", "medium", "high", "xhigh", "max")
 
 
 def test_c3_default_effort_in_config_loader_is_high() -> None:
@@ -295,3 +304,103 @@ def test_c3_default_effort_in_config_loader_is_high() -> None:
     # assert that ``effort`` is one of the valid levels and that the
     # loader contract documents "high" as the default.
     assert cfg.CONFIG.get("effort", "high") in ("low", "medium", "high", "max")
+
+
+# ---------------------------------------------------------------------------
+# C2: capability registry from get_server_info() model entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _clean_capability_registry():
+    """Isolate registry mutations from other tests (class-level state)."""
+    saved = EffortLabel._capability_levels
+    EffortLabel._capability_levels = {}
+    yield
+    EffortLabel._capability_levels = saved
+
+
+SDK_MODELS_SAMPLE = [
+    {
+        "value": "default",
+        "displayName": "Default (recommended)",
+        "description": "Opus 4.8 with 1M context \N{MIDDLE DOT} Best for everyday tasks",
+        "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
+    },
+    {
+        "value": "claude-fable-5[1m]",
+        "displayName": "Fable",
+        "description": "Fable 5 \N{MIDDLE DOT} Most capable",
+        "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
+    },
+    {
+        "value": "sonnet",
+        "displayName": "Sonnet",
+        "description": "Sonnet 4.6 \N{MIDDLE DOT} Efficient for routine tasks",
+        "supportedEffortLevels": ["low", "medium", "high", "max"],
+    },
+    # No supportedEffortLevels -- must NOT enter the registry.
+    {
+        "value": "haiku",
+        "displayName": "Haiku",
+        "description": "Haiku 4.5 \N{MIDDLE DOT} Fastest",
+    },
+    # Legacy pin shape -- no metadata either.
+    {"value": "claude-opus-4-6", "displayName": "Opus 4.6", "description": "Opus 4.6"},
+]
+
+
+class TestC2CapabilityRegistry:
+    """``levels_for_model`` prefers CLI-advertised capability metadata."""
+
+    def test_c2_registry_resolves_value_displayname_and_short_name(
+        self, _clean_capability_registry
+    ) -> None:
+        EffortLabel.update_model_capabilities(SDK_MODELS_SAMPLE)
+        expected = ("low", "medium", "high", "xhigh", "max")
+        # Routable value, displayName, and the short name the footer
+        # derives from the description all resolve.
+        assert EffortLabel.levels_for_model("claude-fable-5[1m]") == expected
+        assert EffortLabel.levels_for_model("Fable") == expected
+        assert EffortLabel.levels_for_model("Fable 5") == expected
+
+    def test_c2_registry_beats_family_fallback(
+        self, _clean_capability_registry
+    ) -> None:
+        """The CLI advertising ``max`` on Sonnet overrides the static
+        fallback (which conservatively omits it)."""
+        EffortLabel.update_model_capabilities(SDK_MODELS_SAMPLE)
+        assert "max" in EffortLabel.levels_for_model("Sonnet")
+        assert "max" in EffortLabel.levels_for_model("sonnet")
+
+    def test_c2_entries_without_metadata_use_family_fallback(
+        self, _clean_capability_registry
+    ) -> None:
+        EffortLabel.update_model_capabilities(SDK_MODELS_SAMPLE)
+        # Haiku carried no supportedEffortLevels -> static fallback.
+        assert EffortLabel.levels_for_model("haiku") == ("low", "medium", "high")
+        # Legacy pin without metadata -> opus family fallback.
+        assert EffortLabel.levels_for_model("claude-opus-4-6") == (
+            "low",
+            "medium",
+            "high",
+            "max",
+        )
+
+    def test_c2_empty_registry_preserves_fallback_behavior(
+        self, _clean_capability_registry
+    ) -> None:
+        """Old CLIs without capability metadata behave as before."""
+        EffortLabel.update_model_capabilities([])
+        assert EffortLabel.levels_for_model("sonnet") == ("low", "medium", "high")
+        assert EffortLabel.levels_for_model(None) == EffortLabel.UNKNOWN_MODEL_LEVELS
+
+    def test_c2_malformed_metadata_is_skipped(self, _clean_capability_registry) -> None:
+        EffortLabel.update_model_capabilities(
+            [
+                {"value": "weird-a", "supportedEffortLevels": "high"},
+                {"value": "weird-b", "supportedEffortLevels": []},
+                {"value": "weird-c", "supportedEffortLevels": [1, 2]},
+            ]
+        )
+        assert EffortLabel._capability_levels == {}

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from claudechic.app import (
-    DEFAULT_EXTRA_MODEL_ENTRIES,
+    LEGACY_MODEL_PINS,
     _merge_model_extras,
 )
 from claudechic.commands import _is_valid_model, _invalid_model_message
@@ -22,7 +22,7 @@ from claudechic.formatting import get_context_window
 
 
 def test_merge_appends_default_extras():
-    """Default extras are appended to an SDK list they don't overlap with."""
+    """Legacy pins are appended to an SDK list they don't overlap with."""
     sdk = [
         {"value": "default", "displayName": "Default"},
         {"value": "opus[1m]", "displayName": "Opus 4.7 (1M context)"},
@@ -35,7 +35,7 @@ def test_merge_appends_default_extras():
 
     # All default extras appear.
     values = [m["value"] for m in merged]
-    for extra in DEFAULT_EXTRA_MODEL_ENTRIES:
+    for extra in LEGACY_MODEL_PINS:
         assert extra["value"] in values
 
     # The user's target versions are present (including 1M variants).

--- a/tests/test_scope_guard.py
+++ b/tests/test_scope_guard.py
@@ -135,13 +135,13 @@ def test_all_user_named_features_shipped_agent_type() -> None:
 
 
 def test_all_user_named_features_shipped_effort() -> None:
-    """C: ``Agent.effort`` exists with one of the four enum values."""
+    """C: ``Agent.effort`` exists with one of the valid enum values."""
     from claudechic.agent import Agent
 
     agent = Agent(name="scope-guard-probe", cwd=REPO_ROOT)
     assert hasattr(agent, "effort"), "Agent must expose .effort"
-    assert agent.effort in {"low", "medium", "high", "max"}, (
-        f"Agent.effort must be one of low|medium|high|max; got {agent.effort!r}"
+    assert agent.effort in {"low", "medium", "high", "xhigh", "max"}, (
+        f"Agent.effort must be one of low|medium|high|xhigh|max; got {agent.effort!r}"
     )
 
 


### PR DESCRIPTION
## Problem

Two hardcodings have drifted from what the Claude Code CLI actually supports:

1. **Effort snapping assumed `max` is Opus-only.** `get_server_info()` now advertises `supportedEffortLevels` per model, and it says otherwise: Fable supports `low/medium/high/xhigh/max`, Sonnet 4.6 supports `max`. Switching to Fable snapped a user's `max` down to `medium` for no reason, and `xhigh` (the Claude Code default effort for Opus 4.7+) wasn't offered at all.
2. **`DEFAULT_EXTRA_MODEL_ENTRIES` invited per-release churn** (see #60). New models arrive in the picker automatically via `get_server_info()` when the installed CLI updates — the extras list is only needed for *old* pinned versions the CLI stopped advertising, but nothing said so.

## Changes

**Effort levels are now capability-driven:**
- `EffortLabel` keeps a registry populated from the SDK model list (`update_model_capabilities`), keyed by each entry's `value`, `displayName`, and the short name the footer derives from `description` — the three shapes of model string the app passes around. `levels_for_model` consults it before the static family fallbacks.
- Static fallbacks remain (unchanged, conservative) for legacy pins and CLIs old enough not to report metadata; a `fable` family fallback is added.
- `xhigh` joins the global ordering, display strings, `/settings` enum, and `Agent.effort` Literal.
- Wired in `_update_slash_commands`: capabilities refresh right before the footer model write triggers the snap logic.

**Legacy pins policy:**
- `DEFAULT_EXTRA_MODEL_ENTRIES` → `LEGACY_MODEL_PINS` with an explicit policy comment: never add newly released models here; add an entry only when the CLI *drops* a model users still want to pin. (This is why #60 became stale — `claude-opus-4-8` was already flowing through dynamically.)
- Fixed stale config-path references: the override lives in `~/.claudechic/config.yaml`, not `~/.claude/.claudechic.yaml`.
- `models.extra` entries may declare `supportedEffortLevels` to feed the effort picker.

**Docs:**
- `docs/configuration.md`: new `effort` and `models.extra` reference entries.
- `claudechic/context/CLAUDE.md` (awareness rule) and `claudechic/context/multi-agent-architecture.md`: effort description updated to the capability-driven behavior.

## Testing

- Full suite: 963 passed, 1 skipped, 2 xfailed
- New tests: registry resolution by value/displayName/short-name, registry-beats-fallback, metadata-less entries fall back, empty registry preserves old behavior, malformed metadata skipped
- `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)