### PR TITLE
feat(sidebar): expand right sidebar into unused width + adaptive truncation

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -392,9 +392,11 @@ class ChatApp(App):
     # Toast debounce: suppress repeat toasts for the same key within this window
     TOAST_COOLDOWN_SECONDS: float = 10.0
 
-    # Width thresholds for layout (sidebar=28, min chat=80)
+    # Width thresholds for layout (min chat=80)
     SIDEBAR_MIN_WIDTH = 110  # Below this, hide sidebar
-    CENTERED_SIDEBAR_WIDTH = 140  # Above this, center chat while showing sidebar
+    SIDEBAR_WIDTH = 28  # Base/min sidebar width (matches styles.tcss #right-sidebar)
+    SIDEBAR_MAX_WIDTH = 48  # Cap when growing into unused horizontal space
+    CHAT_MAX_WIDTH = 100  # Matches styles.tcss #chat-column max-width
 
     def __init__(
         self,
@@ -3348,7 +3350,6 @@ class ChatApp(App):
         show_sidebar_inline = width >= self.SIDEBAR_MIN_WIDTH
         show_overlay = not show_sidebar_inline and self._sidebar_overlay_open
         show_hamburger = not show_sidebar_inline and not self._sidebar_overlay_open
-        sidebar_shift = show_sidebar_inline and width < self.CENTERED_SIDEBAR_WIDTH
         hide_sidebar = not (show_sidebar_inline or show_overlay)
 
         # Apply classes - set_class is a no-op if state already matches
@@ -3358,7 +3359,19 @@ class ChatApp(App):
         self.hamburger_btn.set_class(
             show_hamburger and needs_attention, "needs-attention"
         )
-        main.set_class(sidebar_shift, "sidebar-shift")
+        # When the sidebar is inline, left-align the chat column and dock the
+        # sidebar to the right edge (see #main.sidebar-inline in styles.tcss).
+        main.set_class(show_sidebar_inline, "sidebar-inline")
+
+        # Grow the sidebar into horizontal space the chat column can't use
+        # (it caps at CHAT_MAX_WIDTH). Clamp between the base and max widths;
+        # docked right, so any surplus falls between chat and sidebar.
+        if show_sidebar_inline:
+            surplus = width - self.CHAT_MAX_WIDTH
+            sidebar_w = max(self.SIDEBAR_WIDTH, min(self.SIDEBAR_MAX_WIDTH, surplus))
+            self.right_sidebar.styles.width = sidebar_w
+        elif show_overlay:
+            self.right_sidebar.styles.width = self.SIDEBAR_WIDTH
 
         # Reset overlay state when sidebar is shown inline (overlay is only
         # meaningful on narrow terminals).

--- a/claudechic/styles.tcss
+++ b/claudechic/styles.tcss
@@ -272,8 +272,10 @@ ShellOutputWidget #shell-output {
     align: center top;
 }
 
-/* Shift left when sidebar visible but not enough room to center */
-#main.sidebar-shift {
+/* Sidebar inline: chat column sits left, sidebar docks to the right edge
+   (width set dynamically in _layout_right_sidebar_inner). Any surplus width
+   falls between the capped chat column and the sidebar. */
+#main.sidebar-inline {
     align: left top;
 }
 
@@ -583,17 +585,13 @@ WorktreePrompt, ModelPrompt {
     color: $text-muted;
 }
 
-/* Right sidebar - agents + todos stacked */
+/* Right sidebar - agents + todos stacked. Docked to the right edge; the
+   width (28..48) is set dynamically in _layout_right_sidebar_inner so the
+   panel grows into terminal width the chat column leaves unused. */
 #right-sidebar {
     width: 28;
     height: 100%;
-    /* Negative margin shifts chat+sidebar group left so chat is centered */
-    margin-right: -28;
-}
-
-/* When shifted left, sidebar takes normal space */
-#main.sidebar-shift #right-sidebar {
-    margin-right: 0;
+    dock: right;
 }
 
 #right-sidebar.hidden {

--- a/claudechic/widgets/layout/guards.py
+++ b/claudechic/widgets/layout/guards.py
@@ -67,33 +67,56 @@ class GuardItem(Static):
             self.row = row
             super().__init__()
 
-    # Front-truncation budget for rule ids (rows are height 1; without
-    # truncation a long id word-wraps onto a clipped second line and the
-    # visible row shows only the marker).
+    # Fallback front-truncation budget for rule ids, used before the widget
+    # has been laid out (content_size unknown). Once a width is known, the
+    # budget adapts to it so a wider sidebar shows more of the id. Rows are
+    # height 1; without truncation a long id word-wraps onto a clipped second
+    # line and the visible row shows only the marker.
     max_id_length = 18
+    # Never truncate below this many chars (keeps ".." + a few chars readable).
+    min_id_length = 6
 
     def __init__(self, row: GuardRow) -> None:
         super().__init__()
         self.row = row
         self.tooltip = row.message
 
-    def _truncate_front(self, name: str) -> str:
+    def _truncate_front(self, name: str, budget: int) -> str:
         """Truncate from the front (the trailing rule name disambiguates)."""
-        if len(name) > self.max_id_length:
-            return ".." + name[-(self.max_id_length - 2) :]
+        if len(name) > budget:
+            return ".." + name[-(budget - 2) :]
         return name
+
+    def _id_budget(self) -> int:
+        """Chars available for the rule id, derived from the rendered width.
+
+        Width is shared between the state marker (marker + separator space),
+        the id, and the trailing ``" (enforcement)"`` suffix. Falls back to
+        ``max_id_length`` before the widget has a known content width.
+        """
+        marker = _STATE_MARKERS.get(self.row.state, ("[?] ", "dim"))[0]
+        overhead = len(marker) + 1 + len(f" ({self.row.enforcement})")
+        avail = self.content_size.width
+        if avail <= 0:
+            return self.max_id_length
+        return max(self.min_id_length, avail - overhead)
 
     def render(self) -> Text:
         marker, style = _STATE_MARKERS.get(self.row.state, ("[?] ", "dim"))
         id_style = "dim" if self.row.state == "dormant" else ""
         text = Text.assemble(
             (marker + " ", style),
-            (self._truncate_front(self.row.display_id), id_style),
+            (self._truncate_front(self.row.display_id, self._id_budget()), id_style),
             (f" ({self.row.enforcement})", "dim"),
         )
         text.no_wrap = True
         text.overflow = "ellipsis"
         return text
+
+    def on_resize(self, event) -> None:  # noqa: ARG002
+        # Re-render so the id truncation budget tracks the sidebar width
+        # (the panel grows into unused horizontal space).
+        self.refresh()
 
     def on_click(self, event) -> None:  # noqa: ARG002
         self.post_message(self.Toggled(self.row))

--- a/claudechic/widgets/layout/sidebar.py
+++ b/claudechic/widgets/layout/sidebar.py
@@ -205,7 +205,12 @@ class FileItem(SidebarItem):
             self.file_path = file_path
             super().__init__()
 
+    # Fallback front-truncation budget, used before the widget has been laid
+    # out (content_size unknown). Once a width is known the budget adapts to
+    # it so a wider sidebar shows more of the path.
     max_name_length: int = 14
+    # Never truncate the name below this many chars.
+    min_name_length: int = 6
 
     def __init__(
         self,
@@ -220,15 +225,32 @@ class FileItem(SidebarItem):
         self.deletions = deletions
         self.untracked = untracked
 
-    def _truncate_front(self, name: str) -> str:
+    def _truncate_front(self, name: str, budget: int) -> str:
         """Truncate from front with ellipsis if too long."""
-        if len(name) > self.max_name_length:
-            return "…" + name[-(self.max_name_length - 1) :]
+        if len(name) > budget:
+            return "…" + name[-(budget - 1) :]
         return name
+
+    def _name_budget(self) -> int:
+        """Chars available for the path, derived from the rendered width.
+
+        Width is shared between the optional ``"U "`` prefix, the path, and
+        the ``" +adds"`` / ``" -dels"`` stat suffixes. Falls back to
+        ``max_name_length`` before the widget has a known content width.
+        """
+        overhead = 2 if self.untracked else 0
+        if self.additions:
+            overhead += len(f" +{self.additions}")
+        if self.deletions:
+            overhead += len(f" -{self.deletions}")
+        avail = self.content_size.width
+        if avail <= 0:
+            return self.max_name_length
+        return max(self.min_name_length, avail - overhead)
 
     def render(self) -> Text:
         """Render the file item text."""
-        name = self._truncate_front(str(self.file_path))
+        name = self._truncate_front(str(self.file_path), self._name_budget())
         parts: list[tuple[str, str]] = []
         if self.untracked:
             parts.append(("U ", "dim yellow"))
@@ -238,6 +260,11 @@ class FileItem(SidebarItem):
         if self.deletions:
             parts.append((f" -{self.deletions}", "dim red"))
         return Text.assemble(*parts)
+
+    def on_resize(self, event) -> None:  # noqa: ARG002
+        # Re-render so the truncation budget tracks the sidebar width
+        # (the panel grows into unused horizontal space).
+        self.refresh()
 
     def on_click(self, event) -> None:
         self.post_message(self.Selected(self.file_path))

--- a/tests/test_guard_overrides.py
+++ b/tests/test_guard_overrides.py
@@ -458,6 +458,43 @@ class TestGuardsPanelWidget:
             assert "[x]" in items[0].render().plain
             assert "[.]" in items[1].render().plain
 
+    async def test_id_truncation_adapts_to_width(self):
+        from textual.app import App, ComposeResult
+
+        from claudechic.widgets import GuardItem, GuardRow, GuardsPanel
+
+        long_id = "tutorial_toy_project:R-TOY-01b"
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield GuardsPanel(id="guards-panel")
+
+        row = GuardRow(
+            rule_id=long_id,
+            display_id=long_id,
+            enforcement="deny",
+            state="dormant",
+            message="m",
+        )
+
+        # Wide panel: the full id fits without truncation.
+        app = TestApp()
+        async with app.run_test(size=(80, 20)) as pilot:
+            app.query_one(GuardsPanel).update_guards([row])
+            await pilot.pause()
+            plain = app.query_one(GuardItem).render().plain
+            assert long_id in plain, f"wide panel should show full id, got {plain!r}"
+
+        # Narrow panel: the id is front-truncated so the enforcement suffix
+        # stays visible on the single-line row.
+        app2 = TestApp()
+        async with app2.run_test(size=(24, 20)) as pilot:
+            app2.query_one(GuardsPanel).update_guards([row])
+            await pilot.pause()
+            plain = app2.query_one(GuardItem).render().plain
+            assert long_id not in plain, "narrow panel should truncate the id"
+            assert ".." in plain, f"expected front-truncation marker, got {plain!r}"
+
     async def test_click_posts_toggled_message(self):
         from textual.app import App, ComposeResult
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1257,6 +1257,31 @@ async def test_files_section_scrolls_with_many_files():
 
 
 @pytest.mark.asyncio
+async def test_file_item_truncation_adapts_to_width():
+    """FileItem shows more of the path when the sidebar is wider."""
+    from pathlib import Path
+
+    from claudechic.widgets.layout.sidebar import FileItem
+
+    long_path = "src/some/deeply/nested/module_name.py"
+
+    # Wide: the full path fits without truncation.
+    app = WidgetTestApp(lambda: FileItem(Path(long_path)))
+    async with app.run_test(size=(80, 20)) as pilot:
+        await pilot.pause()
+        plain = app.query_one(FileItem).render().plain
+        assert long_path in plain, f"wide panel should show full path, got {plain!r}"
+
+    # Narrow: the path is front-truncated with the ellipsis marker.
+    app2 = WidgetTestApp(lambda: FileItem(Path(long_path)))
+    async with app2.run_test(size=(24, 20)) as pilot:
+        await pilot.pause()
+        plain = app2.query_one(FileItem).render().plain
+        assert long_path not in plain, "narrow panel should truncate the path"
+        assert "…" in plain, f"expected front-truncation marker, got {plain!r}"
+
+
+@pytest.mark.asyncio
 async def test_files_section_visible_with_workflow_active(mock_sdk):
     """_layout_sidebar_contents must compact agents when workflow is active.
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1263,21 +1263,26 @@ async def test_file_item_truncation_adapts_to_width():
 
     from claudechic.widgets.layout.sidebar import FileItem
 
-    long_path = "src/some/deeply/nested/module_name.py"
+    # str(Path(...)) uses OS-native separators (backslashes on Windows), and
+    # FileItem renders str(self.file_path) -- so compare against that form.
+    path = Path("src/some/deeply/nested/module_name.py")
+    rendered_path = str(path)
 
     # Wide: the full path fits without truncation.
-    app = WidgetTestApp(lambda: FileItem(Path(long_path)))
+    app = WidgetTestApp(lambda: FileItem(path))
     async with app.run_test(size=(80, 20)) as pilot:
         await pilot.pause()
         plain = app.query_one(FileItem).render().plain
-        assert long_path in plain, f"wide panel should show full path, got {plain!r}"
+        assert rendered_path in plain, (
+            f"wide panel should show full path, got {plain!r}"
+        )
 
     # Narrow: the path is front-truncated with the ellipsis marker.
-    app2 = WidgetTestApp(lambda: FileItem(Path(long_path)))
+    app2 = WidgetTestApp(lambda: FileItem(path))
     async with app2.run_test(size=(24, 20)) as pilot:
         await pilot.pause()
         plain = app2.query_one(FileItem).render().plain
-        assert long_path not in plain, "narrow panel should truncate the path"
+        assert rendered_path not in plain, "narrow panel should truncate the path"
         assert "…" in plain, f"expected front-truncation marker, got {plain!r}"
 
 


### PR DESCRIPTION
## Summary

The right sidebar was a fixed 28 cols while the chat column caps at 100, so on wide terminals the surplus width became empty margin and sidebar content (guard rule ids, file paths) stayed clipped. This makes the sidebar grow into that unused space and its rows use the extra room.

## Changes

- **Grow the sidebar into unused width** (`app.py`, `styles.tcss`): dock the sidebar to the right, left-align the chat column, and size the sidebar dynamically `28..48` cols based on `terminal_width - CHAT_MAX_WIDTH`. Replaces the old negative-margin centering trick / `sidebar-shift` class with `sidebar-inline`.
- **Adaptive guard-id truncation** (`widgets/layout/guards.py`): `GuardItem` sizes its rule-id budget from the rendered width (minus marker + `(enforcement)` suffix) instead of a hardcoded 18 chars; re-renders on resize.
- **Adaptive Files-section truncation** (`widgets/layout/sidebar.py`): `FileItem` sizes its path budget from the rendered width (minus the `U ` prefix and +/- stat suffixes) instead of a hardcoded 14 chars; re-renders on resize.

## Behavior by width

- `< 110`: unchanged (hidden, hamburger/overlay).
- `110-128`: sidebar stays at 28.
- `128-148`: sidebar grows 28 -> 48.
- `> 148`: sidebar capped at 48, docked right, gap opens between chat and sidebar.

## Tests

- New `test_id_truncation_adapts_to_width` (guards) and `test_file_item_truncation_adapts_to_width` (files): full text at 80 cols, front-truncated at 24 cols.
- Existing sidebar/layout suites pass; no test asserted on the old fixed width or centering margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)