### PR TITLE
feat(guardrails): broaden no_rm_rf to home paths and flag variants

### DIFF
--- a/claudechic/defaults/global/rules.yaml
+++ b/claudechic/defaults/global/rules.yaml
@@ -1,9 +1,12 @@
 - id: no_rm_rf
   trigger: PreToolUse/Bash
   enforcement: deny
+  # Recursive+force rm (combined -rf/-fr/-Rf, split -r -f, or --recursive
+  # --force, in any order) targeting a root/home path: / , ~, or $HOME.
+  # Relative targets (build/, ./x) are intentionally allowed.
   detect:
-    pattern: "rm\\s+-rf\\s+/"
-  message: "Dangerous: rm -rf on absolute path. Request override if intentional."
+    pattern: "\\brm\\s+(-\\w*[rR]\\w*f\\w*|-\\w*f\\w*[rR]\\w*|-[rR]\\s+-f|-f\\s+-[rR]|--recursive\\s+--force|--force\\s+--recursive)(\\s+-\\S+)*\\s+(/|~|\\$\\{?HOME\\b)"
+  message: "Dangerous: recursive force-remove of a root/home path (/ , ~, or $HOME). Request override if intentional."
 
 - id: warn_sudo
   trigger: PreToolUse/Bash

--- a/tests/test_no_rm_rf_pattern.py
+++ b/tests/test_no_rm_rf_pattern.py
@@ -1,0 +1,66 @@
+"""Regression coverage for the bundled global ``no_rm_rf`` guardrail pattern.
+
+Other guardrail tests use inline rule fixtures; this one asserts the actual
+``claudechic/defaults/global/rules.yaml`` pattern so broadening/narrowing it
+is a deliberate, test-visible change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_RULES = Path(__file__).resolve().parents[1] / "claudechic/defaults/global/rules.yaml"
+
+
+def _pattern() -> re.Pattern[str]:
+    entries = yaml.safe_load(_RULES.read_text(encoding="utf-8"))
+    rule = next(e for e in entries if e["id"] == "no_rm_rf")
+    return re.compile(rule["detect"]["pattern"])
+
+
+BLOCK = [
+    "rm -rf /",
+    "rm -rf /home/moharb/data",
+    "rm  -rf   /tmp/foo",
+    "rm -fr /",
+    "rm -Rf /",
+    "rm -rfv /",
+    "rm -r -f /",
+    "rm -f -r /",
+    "rm --recursive --force /",
+    "rm --force --recursive /",
+    "rm -rf ~",
+    "rm -rf ~/data",
+    "rm -rf $HOME",
+    "rm -rf ${HOME}",
+    "rm -rf ${HOME}/x",
+    "sudo rm -rf /",
+    "rm -rf -- /",
+    "rm -rf /*",
+]
+
+ALLOW = [
+    "rm -rf demo_preview/",
+    "rm -rf ./demo_preview",
+    "rm -rf build",
+    "rm -r node_modules",
+    "rm -f file.txt",
+    "rm -rf $HOMELAB",  # $HOME\b must not match $HOMELAB
+    "confirm -rf /path",  # \brm must not match inside 'confirm'
+    "git rm -rf src/old",  # real relative target
+]
+
+
+def test_no_rm_rf_blocks_root_and_home_targets():
+    rx = _pattern()
+    for cmd in BLOCK:
+        assert rx.search(cmd), f"expected {cmd!r} to be blocked"
+
+
+def test_no_rm_rf_allows_relative_and_lookalikes():
+    rx = _pattern()
+    for cmd in ALLOW:
+        assert not rx.search(cmd), f"expected {cmd!r} to be allowed"


### PR DESCRIPTION
## Summary

The `no_rm_rf` deny guardrail only matched the combined-flag absolute-path form (`rm` + `-rf` + `/`). This broadens it to cover the dangerous cases it was missing, while keeping relative-path deletes allowed.

## Now blocked (previously slipped through)

- Home targets: `~`, `~/path`, `$HOME`, `${HOME}`, `${HOME}/x`
- Flag variants: `-fr`, `-Rf`, `-rfv`, split `-r -f` / `-f -r`, and `--recursive --force` (either order)

## Still allowed (false-positives avoided)

- Relative targets: `build`, `./x`, `git rm -rf src/old`
- Look-alikes: `$HOMELAB` (via `HOME\b` boundary) and `confirm -rf /path` (via `\brm` boundary)

## Tests

`tests/test_no_rm_rf_pattern.py` (new) loads the real bundled `claudechic/defaults/global/rules.yaml` pattern and asserts an 18-case block matrix and an 8-case allow matrix, so future narrowing/broadening is test-visible.

## Note

Matching is still a substring scan of the whole command string, so an incidental mention of the pattern inside a larger script can trip it (acceptable for a deny-with-override safety net). Requires a claudechic restart to pick up the new bundled pattern at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
