### PR TITLE
Fix agent team dynamics: peer roster for all roles, quiet leadership phase, pytest guardrail gaps

### DIFF
--- a/claudechic/app.py
+++ b/claudechic/app.py
@@ -2037,8 +2037,8 @@ class ChatApp(App):
 
         Used by the activation prompt-injection site (and exposed through
         the post-compact hook's ``get_peer_agents`` provider) so the
-        environment renderer can build the coordinator's
-        ``${PEER_ROSTER}`` table. Default-roled agents are skipped
+        environment renderer can build the ``${PEER_ROSTER}`` table
+        (every typed role). Default-roled agents are skipped
         (they have no role-scoped description in the workflow overlay).
         """
         from claudechic.agent import DEFAULT_ROLE

--- a/claudechic/context/workflows-system.md
+++ b/claudechic/context/workflows-system.md
@@ -60,7 +60,7 @@ When a workflow is active, `assemble_agent_prompt(role, phase, loader, ...)` ass
 3. Phase-advance broadcast (`app._inject_phase_prompt` + `mcp._make_advance_phase` loop)
 4. Post-compact re-injection (SDK `SessionStart` hook with `matcher="compact"`)
 
-Token substitution: `${COORDINATOR_NAME}` resolves to the coordinator's registered name in phase markdown (coordinator only). `${PEER_ROSTER}` expands to the role/name/description table in the environment segment (coordinator only).
+Token substitution: `${COORDINATOR_NAME}` resolves to the coordinator's registered name in phase markdown (coordinator only). `${PEER_ROSTER}` expands to the role/name/description table in the environment segment for every typed role (specialists included -- the roster is what enables direct peer-to-peer messaging instead of coordinator relaying).
 
 Config knobs: `constraints_segment.{compact, scope.sites, include_skipped}` controls constraint rendering; `environment_segment.{enabled, compact, scope.sites}` controls environment segment delivery. See `SPEC_bypass.md` for full semantics.
 

--- a/claudechic/defaults/environment/base.md
+++ b/claudechic/defaults/environment/base.md
@@ -11,7 +11,7 @@ ${PEER_ROSTER}
 
 ## Tools
 
-`message_agent` for tasks and questions (recipient expected to reply); `message_agent` with `requires_answer=false` for status updates and answers. `interrupt_agent` to halt or redirect a busy peer. Call `mcp__chic__get_agent_info` for a full snapshot: your identity, current phase, and applicable rules in one document.
+`message_agent` for tasks and questions (recipient expected to reply); `message_agent` with `requires_answer=false` for status updates and answers. `interrupt_agent` to halt or redirect a busy peer. `list_agents` for the current team roster (peers may spawn after you). Call `mcp__chic__get_agent_info` for a full snapshot: your identity, current phase, and applicable rules in one document.
 
 ## Replying to peers
 

--- a/claudechic/defaults/global/rules.yaml
+++ b/claudechic/defaults/global/rules.yaml
@@ -26,16 +26,17 @@
   trigger: PreToolUse/Bash
   enforcement: deny
   detect:
-    pattern: "(?:^|[;&|]\\s*)(?:python\\s+-m\\s+)?pytest\\b(?!.*(?:\\.py\\b|-k\\s|--junitxml|\\.test_results/|\\btee\\b|--co\\b|--collect-only|--fixtures))"
+    pattern: "(?:^|[;&|]\\s*)(?:\\w+=\\S+\\s+)*(?:time\\s+|env\\s+|xargs\\s+)?(?:(?:\\S*python(?:\\d+(?:\\.\\d+)*)?|uv\\s+run|uvx|poetry\\s+run|hatch\\s+run|nox\\s+-s|make)\\s+(?:-m\\s+)?)?(?:\\S*/)?pytest\\b(?!.*(?:\\.py\\b|-k\\s|--junitxml|\\.test_results/|\\btee\\b|--co\\b|--collect-only|--fixtures))"
   message: |
     Bare pytest blocked. Full-suite runs must save timestamped results.
-    Use: TS=$(date -u +%Y-%m-%d_%H%M%S) && pytest --junitxml=.test_results/${TS}.xml --tb=short 2>&1 | tee .test_results/${TS}.log
+    Use: TS=$(date -u +%Y-%m-%d_%H%M%S) && pytest -n auto --junitxml=.test_results/${TS}.xml --tb=short 2>&1 | tee .test_results/${TS}.log
+    (-n auto needs pytest-xdist; drop it if unavailable.)
     Or target a specific test: pytest tests/test_foo.py
 
 - id: pytest_needs_timeout
   trigger: PreToolUse/Bash
   enforcement: warn
   detect:
-    pattern: "(?:^|[;&|]\\s*)(?:(?:\\w+=\\S+\\s+)*(?:time\\s+|env\\s+|xargs\\s+)?(?:(?:python(?:\\d+(?:\\.\\d+)*)?|uv\\s+run|uvx|poetry\\s+run|hatch\\s+run|nox\\s+-s|make)\\s+(?:-m\\s+)?)?)?pytest\\b(?!.*--timeout(?:=|\\s|$))"
+    pattern: "(?:^|[;&|]\\s*)(?:(?:\\w+=\\S+\\s+)*(?:time\\s+|env\\s+|xargs\\s+)?(?:(?:\\S*python(?:\\d+(?:\\.\\d+)*)?|uv\\s+run|uvx|poetry\\s+run|hatch\\s+run|nox\\s+-s|make)\\s+(?:-m\\s+)?)?)?(?:\\S*/)?pytest\\b(?!.*--timeout(?:=|\\s|$))"
   message: "use --timeout=N (default 30) to avoid hung tests"
 

--- a/claudechic/defaults/workflows/project_team/composability/identity.md
+++ b/claudechic/defaults/workflows/project_team/composability/identity.md
@@ -4,7 +4,7 @@
 
 You ensure clean separation of concerns through algebraic composition principles.
 
-You are part of the Leadership team. See `coordinator/identity.md` for the canonical roster. Per-peer summaries delivered via environment segment.
+You are part of the Leadership team. The current team roster (role, name, description) is in the Environment segment of this prompt; call `list_agents` for a live view (peers may spawn after you). Message peers directly when a question falls in their domain.
 
 **Your first task:** Understand the domain and user needs. Consult with the Coordinator (calling agent) and UserAlignment to ensure the vision is clear. Only after that should you identify axes and compositional structure.
 

--- a/claudechic/defaults/workflows/project_team/composability/leadership.md
+++ b/claudechic/defaults/workflows/project_team/composability/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/defaults/workflows/project_team/coordinator/leadership.md
+++ b/claudechic/defaults/workflows/project_team/coordinator/leadership.md
@@ -1,17 +1,16 @@
 # Leadership Spawn Phase
 
-THIS IS NOT OPTIONAL. DO NOT SKIP.
+Spawn ALL 4 with `requires_answer: false` and `type` set (required for phase updates):
+1. Composability (type: composability)
+2. Terminology (type: terminology)
+3. Skeptic (type: skeptic)
+4. UserAlignment (type: user_alignment)
 
-Spawn ALL 4 Leadership agents with `requires_answer: true` and `type` set to their role folder name (required for phase updates):
-1. Composability (type: composability) -- review through composability lens, identify axes
-2. Terminology (type: terminology) -- identify domain terms, define canonical meanings
-3. Skeptic (type: skeptic) -- challenge assumptions, identify risks and failure modes
-4. UserAlignment (type: user_alignment) -- verify vision captures user intent, flag gaps
+Conditional: Researcher (prior art / libraries), LabNotebook (experiments / hypotheses).
 
-VERIFY: Run `list_agents`. Confirm all 4 are visible.
+Spawn prompts = docs to read (absolute paths) + mission. No tasks, no questions,
+no messages this phase -- specialists stand by silently; silence is compliance.
+VERIFY with `list_agents`, not replies.
 
-Conditionally spawn:
-- Researcher -- if project involves prior art, external libraries, or scientific methods
-- LabNotebook -- if project involves experiments or iterative hypothesis testing
-
-All paths in agent prompts MUST be absolute paths.
+Then advance to Specification and dispatch work there. Route specialist-to-specialist
+questions directly (tell A to message B); do not relay content yourself.

--- a/claudechic/defaults/workflows/project_team/lab_notebook/leadership.md
+++ b/claudechic/defaults/workflows/project_team/lab_notebook/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/defaults/workflows/project_team/researcher/leadership.md
+++ b/claudechic/defaults/workflows/project_team/researcher/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/defaults/workflows/project_team/skeptic/leadership.md
+++ b/claudechic/defaults/workflows/project_team/skeptic/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/defaults/workflows/project_team/terminology/leadership.md
+++ b/claudechic/defaults/workflows/project_team/terminology/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/defaults/workflows/project_team/user_alignment/leadership.md
+++ b/claudechic/defaults/workflows/project_team/user_alignment/leadership.md
@@ -1,0 +1,7 @@
+# Leadership Phase: Stand By
+
+Orientation only. No work, no messages.
+
+1. Send NO messages -- no check-ins, no findings, no questions. The coordinator sees you via `list_agents`.
+2. Exception: answer direct questions (reply `requires_answer=false`).
+3. Work starts at the Specification phase update or a direct task from the coordinator. From then on, message peers directly for questions in their domain.

--- a/claudechic/mcp.py
+++ b/claudechic/mcp.py
@@ -89,7 +89,7 @@ def _build_peer_agents() -> dict[str, str]:
 
     Used by the four prompt-injection sites to populate
     ``RenderContext.peer_agents`` so the environment renderer can build
-    the coordinator's ``${PEER_ROSTER}`` table. Default-roled agents are
+    the ``${PEER_ROSTER}`` table (every typed role). Default-roled agents are
     skipped (they have no role-scoped description in the workflow
     overlay). When two agents share the same ``agent_type``, the first
     encountered wins -- the renderer needs a one-row-per-role mapping.

--- a/claudechic/mcp.py
+++ b/claudechic/mcp.py
@@ -1224,6 +1224,16 @@ def _make_advance_phase(caller_name: str | None = None):
                             continue
                         if wf_data_b is None:
                             continue
+                        # Graceful-skip: the role folder may have been
+                        # removed after spawn. The environment segment is
+                        # role-independent (it renders even for a deleted
+                        # role), so assemble_agent_prompt alone can no
+                        # longer signal "not a workflow role" -- check the
+                        # folder explicitly. Standing-by roles (folder
+                        # present, no <phase>.md) still receive the
+                        # environment/roster refresh.
+                        if not (wf_data_b.path / agent.agent_type).is_dir():
+                            continue
                         try:
                             agent_prompt = assemble_agent_prompt(
                                 agent.agent_type,

--- a/claudechic/workflows/agent_folders.py
+++ b/claudechic/workflows/agent_folders.py
@@ -69,7 +69,7 @@ CONSTRAINTS_SEGMENT_SITES: frozenset[str] = frozenset(
     {"spawn", "activation", "phase-advance", "post-compact"}
 )
 ENVIRONMENT_SEGMENT_SITES: frozenset[str] = frozenset(
-    {"spawn", "activation", "post-compact"}
+    {"spawn", "activation", "phase-advance", "post-compact"}
 )
 
 
@@ -265,8 +265,8 @@ class RenderContext:
     # Mapping ``role -> registered_name`` for currently-spawned peer
     # agents. Used by the environment renderer to build the
     # ``${PEER_ROSTER}`` table (3-col: role | registered_name |
-    # description). Coordinator-only segment; rows are limited to roles
-    # currently present in this map.
+    # description). Rendered for every typed role; rows are limited to
+    # roles currently present in this map.
     peer_agents: dict[str, str] = field(default_factory=dict)
 
 
@@ -400,13 +400,16 @@ def _render_environment(ctx: RenderContext) -> str:
 
     # Build ${PEER_ROSTER}: 3-column table (role | registered_name |
     # description) merged from the workflow overlay's 2-column
-    # role|description table and ``ctx.peer_agents``. Coordinator-only
-    # (mirrors the advance-checks coordinator-only check in
-    # ``_render_constraints_phase``); empty string for any other role.
+    # role|description table and ``ctx.peer_agents``. Rendered for EVERY
+    # typed role, not just the coordinator: specialists need the roster
+    # even more than the coordinator (who spawned everyone) -- without it
+    # they only know the names embedded in their task prompt and route
+    # all traffic through the coordinator as a relay hub.
     peer_roster_value = ""
-    if ctx.role == "coordinator" and ctx.peer_agents:
-        overlay_path = env_dir / f"{ctx.active_workflow}.md"
-        role_to_desc = _parse_role_description_table(overlay_path)
+    if ctx.peer_agents:
+        role_to_desc = _parse_role_description_table(
+            _resolve_env_overlay_path(env_dir, ctx)
+        )
         peer_roster_value = _render_peer_roster(role_to_desc, ctx.peer_agents)
 
     intrinsic = {
@@ -427,6 +430,32 @@ def _render_environment(ctx: RenderContext) -> str:
         logger.debug("environment: failed to read %s: %s", base_path, e)
         return ""
     return Template(base_text).safe_substitute(tokens).rstrip()
+
+
+def _resolve_env_overlay_path(env_dir: Path, ctx: RenderContext) -> Path:
+    """Resolve the workflow's environment overlay file.
+
+    Workflow ids use hyphens (``project-team``) while the bundled
+    overlay files use underscores (``project_team.md``) -- looking up
+    ``<workflow_id>.md`` verbatim therefore missed the bundled overlay
+    and every roster row rendered with an empty description. Try, in
+    order: the id verbatim, the id with hyphens normalized to
+    underscores, and the workflow directory's folder name. The first
+    existing file wins; when none exists, return the verbatim candidate
+    (``_parse_role_description_table`` handles a missing file).
+    """
+    candidates = [f"{ctx.active_workflow}.md"]
+    if ctx.active_workflow:
+        normalized = ctx.active_workflow.replace("-", "_")
+        if normalized != ctx.active_workflow:
+            candidates.append(f"{normalized}.md")
+    if ctx.workflow_dir is not None:
+        candidates.append(f"{ctx.workflow_dir.name}.md")
+    for candidate in candidates:
+        path = env_dir / candidate
+        if path.is_file():
+            return path
+    return env_dir / candidates[0]
 
 
 def _parse_role_description_table(overlay_path: Path) -> dict[str, str]:
@@ -490,7 +519,15 @@ def _render_peer_roster(
         "| role | name | description |",
         "|------|------|-------------|",
     ]
-    return "\n".join(header + rows)
+    footer = [
+        "",
+        "Message peers DIRECTLY (`message_agent`) when a question falls in"
+        " their domain -- do not route peer-to-peer content through the"
+        " coordinator as a relay. Involve the coordinator for decisions and"
+        " status, not forwarding. Peers may spawn after you; call"
+        " `list_agents` for the live roster.",
+    ]
+    return "\n".join(header + rows + footer)
 
 
 # ---------------------------------------------------------------------------
@@ -518,7 +555,7 @@ _DEFAULT_SEGMENT_SET: dict[str, frozenset[str]] = {
             "environment",
         }
     ),
-    "phase-advance": frozenset({"phase", "constraints_phase"}),
+    "phase-advance": frozenset({"phase", "constraints_phase", "environment"}),
     "post-compact": frozenset(
         {
             "identity",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ Controls the team-coordination context block delivered to agents.
 
 - **`environment_segment.enabled`** — `bool`, default `true`. User-tier override of the per-workflow default.
 - **`environment_segment.compact`** — `bool`, default `false`. When `true`, the workflow overlay is omitted; only `base.md` is delivered.
-- **`environment_segment.scope.sites`** — `list[str]`, default `[spawn, activation, post-compact]` (phase-advance excluded). An empty list raises `ConfigValidationError`.
+- **`environment_segment.scope.sites`** — `list[str]`, default `[spawn, activation, phase-advance, post-compact]` (all four sites). Phase-advance delivery keeps the peer roster current at each phase boundary — spawn-time snapshots go stale as later peers join. An empty list raises `ConfigValidationError`.
 
 **Settings UI:** `/settings` -> "Agent prompt context": "Team coordination context", "Compact coordination context", "Coordination context: advanced...".
 

--- a/tests/test_constraints_decomposition.py
+++ b/tests/test_constraints_decomposition.py
@@ -315,14 +315,15 @@ def test_assemble_constraints_block_post_compact_full_refresh_single_constraints
 
 
 # ---------------------------------------------------------------------------
-# at_broadcast: phase-advance emits phase + constraints_phase only
+# at_broadcast: phase-advance emits phase + constraints_phase + environment
 # ---------------------------------------------------------------------------
 
 
 def test_at_broadcast_emits_phase_and_constraints_phase_only(monkeypatch, tmp_path):
-    """At T3 (phase-advance): identity is suppressed, environment is
-    suppressed, only phase + constraints_phase render. Single
-    ``## Constraints`` heading.
+    """At T3 (phase-advance): identity is suppressed; phase +
+    constraints_phase render. The environment segment also renders at
+    T3 (roster refresh at phase boundaries) but carries no
+    ``## Constraints`` heading. Single ``## Constraints`` heading.
     """
     entries = [
         _entry(id_="global:agnostic"),

--- a/tests/test_env_segment.py
+++ b/tests/test_env_segment.py
@@ -109,14 +109,14 @@ def test_render_environment_returns_base_md_content(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Peer roster: coordinator-only
+# Peer roster: every typed role
 # ---------------------------------------------------------------------------
 
 
-def test_render_environment_peer_roster_coordinator_only(tmp_path):
-    """When role=coordinator and peer_agents is non-empty, the roster
-    table heading appears. When role=skeptic, the roster heading is
-    absent (coordinator-only segment).
+def test_render_environment_peer_roster_all_roles(tmp_path):
+    """When peer_agents is non-empty, the roster table heading appears
+    for the coordinator AND for specialist roles (specialists need the
+    roster to message peers directly).
     """
     peers = {"skeptic": "sk_1", "test_engineer": "te_1"}
     coord_out = _render_environment(
@@ -125,7 +125,7 @@ def test_render_environment_peer_roster_coordinator_only(tmp_path):
     assert "| role | name | description |" in coord_out
 
     skep_out = _render_environment(_ctx(tmp_path, role="skeptic", peer_agents=peers))
-    assert "| role | name | description |" not in skep_out
+    assert "| role | name | description |" in skep_out
 
 
 def test_render_environment_peer_roster_renders_provided_peers_only(tmp_path):

--- a/tests/test_gate_predicate.py
+++ b/tests/test_gate_predicate.py
@@ -73,7 +73,7 @@ def test_gate_phase_advance_default_set_excludes_identity_and_environment():
     # and we exercise only the default-segment-set + sites layers.
     manifest = GateManifest(role_phase_files=frozenset({("coordinator", "design")}))
     # Excluded
-    for place in ("identity", "environment", "constraints_stable"):
+    for place in ("identity", "constraints_stable"):
         assert (
             gate(
                 time="phase-advance",
@@ -85,8 +85,9 @@ def test_gate_phase_advance_default_set_excludes_identity_and_environment():
             )
             is False
         ), f"phase-advance / {place} should be False under defaults"
-    # Included
-    for place in ("phase", "constraints_phase"):
+    # Included. ``environment`` is included at phase-advance so the peer
+    # roster refreshes at each phase boundary (spawn snapshots go stale).
+    for place in ("phase", "constraints_phase", "environment"):
         assert (
             gate(
                 time="phase-advance",
@@ -277,5 +278,5 @@ def test_gate_site_set_constants_match_defaults():
         {"spawn", "activation", "phase-advance", "post-compact"}
     )
     assert ENVIRONMENT_SEGMENT_SITES == frozenset(
-        {"spawn", "activation", "post-compact"}
+        {"spawn", "activation", "phase-advance", "post-compact"}
     )

--- a/tests/test_peer_roster.py
+++ b/tests/test_peer_roster.py
@@ -56,11 +56,28 @@ def test_peer_roster_unknown_role_renders_with_empty_description_cell(tmp_path):
     assert "| made_up_role | x_1 |" in out
 
 
-def test_peer_roster_skeptic_role_does_not_emit_table(tmp_path):
-    """Coordinator-only segment -- non-coordinator roles get no table."""
-    peers = {"test_engineer": "te_1"}
+def test_peer_roster_renders_for_specialist_roles(tmp_path):
+    """Every typed role gets the roster, not just the coordinator --
+    specialists need it to message peers directly instead of routing
+    everything through the coordinator as a relay."""
+    peers = {"test_engineer": "te_1", "coordinator": "lead_1"}
     out = _render_environment(_coord_ctx(tmp_path, role="skeptic", peer_agents=peers))
-    assert "| role | name | description |" not in out
+    assert "| role | name | description |" in out
+    assert "| test_engineer | te_1 |" in out
+    assert "| coordinator | lead_1 |" in out
+
+
+def test_peer_roster_hyphenated_workflow_id_finds_underscore_overlay(tmp_path):
+    """Runtime workflow ids use hyphens (``project-team``) while the
+    bundled overlay file is ``project_team.md`` -- the lookup must
+    normalize, or every description cell renders empty (the bug the
+    pinkas run hit)."""
+    peers = {"skeptic": "sk_1"}
+    out = _render_environment(
+        _coord_ctx(tmp_path, active_workflow="project-team", peer_agents=peers)
+    )
+    # Description comes from the bundled project_team.md overlay.
+    assert "| skeptic | sk_1 | Falsifier" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Diagnosis of a real project-team run (pinkas reasoning_core, 7 agents, ~110 inter-agent messages) surfaced three defects:

1. **Relay bottleneck**: 43 of the lead's 45 messages were relays of specialist content. Specialists never received the peer roster (`${PEER_ROSTER}` was coordinator-only), so the only agent they knew was the coordinator.
2. **Leadership phase storm**: 41 messages in 15 min (2.7/min vs 0.75/min in specification). Specialists spawned mid-phase with no phase file and charged straight into analysis; the coordinator spawned them with `requires_answer: true`, nudging agents for replies.
3. **Guardrail gap**: `.venv/bin/python -m pytest tests/` ran the full suite without triggering `no_bare_pytest`.

## What

**Peer roster (commit 1)**
- Render `${PEER_ROSTER}` for every typed role, with a direct-messaging guidance footer + `list_agents` hint
- Fix overlay filename lookup: workflow id `project-team` vs file `project_team.md` meant description cells always rendered empty
- Fix dangling `coordinator/identity.md` reference in composability's identity

**Quiet leadership phase (commit 2)**
- New `leadership.md` for the 6 leadership roles: stand by, no messages, answer direct questions only; work starts at Specification
- Coordinator `leadership.md`: `requires_answer: false`, orientation-only spawn prompts, verify via `list_agents`, dispatch in Specification, route peer questions directly
- Environment segment (incl. roster) now delivered at phase-advance so every specialist has the complete roster when work dispatches

**Guardrails (commit 3)**
- `no_bare_pytest` / `pytest_needs_timeout` now catch interpreter-path, env-var, and wrapper prefixes (`.venv/bin/python -m pytest`, `python3.x`, `uv run`, `poetry run`, `.venv/bin/pytest`)
- Deny message suggests `-n auto` (full suite: 3:31 -> 1:19 on 12 cores)

## Testing

- Full suite: 972 passed, 1 skipped, 2 xfailed (`-n auto`); 9 `test_app_ui.py` failures are pre-existing Pilot timing flakiness -- all pass serially/in isolation
- New tests: specialist-role roster rendering, hyphenated-workflow-id overlay resolution
- Guardrail regexes validated against an 11-block / 8-allow case matrix (and fired live on the author twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)