### PR TITLE
feat(chat): one-click Copy button on code blocks

### DIFF
--- a/claudechic/config.py
+++ b/claudechic/config.py
@@ -54,6 +54,9 @@ def _load() -> tuple[dict, bool]:
         config.setdefault(
             "show_message_metadata", True
         )  # Show timestamp/tokens by default
+        config.setdefault(
+            "code_copy_button", True
+        )  # Copy button on code blocks by default
         # claudechic-awareness install toggle (per SPEC §4.3, default True)
         config.setdefault("awareness", {})
         config["awareness"].setdefault("install", True)
@@ -79,6 +82,7 @@ def _load() -> tuple[dict, bool]:
             "recent-tools-expanded": 2,
             "default_permission_mode": "auto",
             "show_message_metadata": True,  # Show timestamp/tokens by default
+            "code_copy_button": True,  # Copy button on code blocks by default
             # claudechic-awareness install toggle (per SPEC §4.3, default True)
             "awareness": {"install": True},
             # SDK thinking-budget level (SPEC C3, default "high").

--- a/claudechic/screens/settings.py
+++ b/claudechic/screens/settings.py
@@ -97,6 +97,12 @@ USER_KEYS: tuple[SettingKey, ...] = (
         editor="bool",
     ),
     SettingKey(
+        key="code_copy_button",
+        label="Code block copy button",
+        tier="user",
+        editor="bool",
+    ),
+    SettingKey(
         key="recent-tools-expanded",
         label="Recent tools expanded",
         tier="user",
@@ -1037,6 +1043,10 @@ class SettingsScreen(Screen[None]):
                 app._update_vi_mode(bool(value))
         elif spec.key == "show_message_metadata":
             # Reactive: existing redraws pick up CONFIG.
+            pass
+        elif spec.key == "code_copy_button":
+            # Applies to code blocks rendered after the toggle; already-mounted
+            # fences keep their current form until the next message.
             pass
         elif spec.key == "recent-tools-expanded":
             pass

--- a/claudechic/widgets/content/safe_markdown.py
+++ b/claudechic/widgets/content/safe_markdown.py
@@ -19,13 +19,143 @@ content that may contain links: chat messages, tool output, plan
 panels, prompt previews, file previews. Importing the bare
 ``textual.widgets.Markdown`` re-introduces the freeze; a comment in
 each call site reminds future contributors why.
+
+``SafeMarkdown`` also swaps Textual's plain code-fence widget for
+``CopyableMarkdownFence`` (via the supported ``get_block_class`` hook),
+which renders a header bar above every fenced code block with the
+language on the left and a one-click ``Copy`` button on the right.
+Terminal commands and snippets an agent produces are the things a user
+most often wants to copy/paste, so the button copies the block's raw
+(un-highlighted) source verbatim.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-from textual.widgets import Markdown
+from textual.app import ComposeResult
+from textual.containers import Horizontal, HorizontalScroll
+from textual.widgets import Label, Markdown, Static
+
+# ``MarkdownFence`` is the block widget Textual instantiates for fenced
+# and indented code blocks. It lives in a private module, but the class
+# itself is stable and is the documented target of the ``BLOCKS`` /
+# ``get_block_class`` extension point we hook below. Importing it by name
+# (rather than pulling it out of ``Markdown.BLOCKS`` dynamically) gives
+# the type checker a concrete base class to reason about.
+from textual.widgets._markdown import MarkdownBlock, MarkdownFence
+
+from claudechic.widgets.primitives.button import Button
+
+log = logging.getLogger(__name__)
+
+
+class CopyableMarkdownFence(MarkdownFence):
+    """A code fence with a header bar carrying the language + a Copy button.
+
+    Layout::
+
+        ┌ header ─────────────────────────────┐
+        │ bash                        ⧉ Copy   │
+        ├ body (horizontally scrollable) ──────┤
+        │ uv tool install …                    │
+        └──────────────────────────────────────┘
+
+    The Copy button copies ``self.code`` -- the block's raw source as
+    parsed by markdown-it, *not* the syntax-highlighted ``Content`` -- so
+    what lands on the clipboard is exactly what you'd paste into a shell.
+    ``self.code`` is refreshed on every streaming update so copies stay
+    correct while an answer is still being written.
+    """
+
+    DEFAULT_CSS = """
+    CopyableMarkdownFence {
+        layout: vertical;
+        height: auto;
+        overflow: hidden;
+    }
+    CopyableMarkdownFence > .fence-header {
+        width: 100%;
+        height: 1;
+        background: $panel;
+    }
+    CopyableMarkdownFence .fence-lang {
+        width: 1fr;
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+        text-style: dim;
+    }
+    CopyableMarkdownFence .fence-copy {
+        width: auto;
+        height: 1;
+        padding: 0 1;
+        color: $text-muted;
+    }
+    CopyableMarkdownFence .fence-copy:hover {
+        color: $text;
+        background: $primary 30%;
+        text-style: bold;
+    }
+    CopyableMarkdownFence > .fence-body {
+        width: 1fr;
+        height: auto;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-size-horizontal: 0;
+    }
+    CopyableMarkdownFence #code-content {
+        width: auto;
+        padding: 1 2;
+    }
+    """
+
+    def _lang_label(self) -> str:
+        """Human-facing language label for the header (never empty)."""
+        return (self.lexer or "").strip() or "text"
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(classes="fence-header"):
+            yield Static(self._lang_label(), classes="fence-lang")
+            yield Button("⧉ Copy", classes="fence-copy")
+        # Keep the code in its own horizontal-scroll region so long lines
+        # scroll independently and the header bar stays pinned. ``set_content``
+        # (called by the parent during streaming) locates the Label by id, so
+        # nesting it here is safe.
+        with HorizontalScroll(classes="fence-body"):
+            yield Label(self._highlighted_code, id="code-content")
+
+    async def _update_from_block(self, block: MarkdownBlock) -> None:
+        # Parent refreshes the highlighted Label content + lexer/token; it does
+        # NOT touch ``self.code``, so a fence updated mid-stream would otherwise
+        # keep copying its first-seen source. Refresh both here.
+        await super()._update_from_block(block)
+        if isinstance(block, MarkdownFence):
+            self.code = block.code
+            try:
+                self.query_one(".fence-lang", Static).update(self._lang_label())
+            except Exception:
+                # Header not mounted yet (update raced compose); the label will
+                # render from the refreshed lexer on first mount.
+                pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        # Only the header Copy button lives inside a fence, so any press here is
+        # a copy request. Stop it so it doesn't bubble to message-level handlers.
+        event.stop()
+        self._copy_code()
+
+    def _copy_code(self) -> None:
+        code = self.code or ""
+        try:
+            # ``App.copy_to_clipboard`` (overridden by ChatApp for OSC-52 +
+            # platform fallbacks) is always present on the running app.
+            self.app.copy_to_clipboard(code)
+            self.app.notify("Copied to clipboard")
+        except Exception:
+            log.exception("Failed to copy code block to clipboard")
+            self.app.notify("Copy failed", severity="error")
 
 
 class SafeMarkdown(Markdown):
@@ -35,8 +165,22 @@ class SafeMarkdown(Markdown):
     the default Textual behavior (e.g. a future controlled-environment
     use case where blocking is acceptable). The default-off posture is
     what protects every existing call site.
+
+    Also routes code-fence blocks to :class:`CopyableMarkdownFence` so
+    every fenced/indented code block gets a one-click Copy button.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("open_links", False)
         super().__init__(*args, **kwargs)
+
+    def get_block_class(self, block_name: str) -> type[MarkdownBlock]:
+        if block_name in ("fence", "code_block"):
+            # Lazy import matches message.py -- avoids importing CONFIG at
+            # module load and honors edits made via /settings without restart
+            # (applies to code blocks rendered after the toggle changes).
+            from claudechic.config import CONFIG
+
+            if CONFIG.get("code_copy_button", True):
+                return CopyableMarkdownFence
+        return super().get_block_class(block_name)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,21 @@ Show timestamp and token count under each chat message.
 show_message_metadata: true
 ```
 
+### `code_copy_button`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Exposed in `/settings`:** yes
+
+Render a header bar above each fenced code block with the language on the
+left and a one-click **Copy** button on the right. The button copies the
+block's raw source (no prose or backticks) -- handy for terminal commands
+and snippets. Set to `false` to render plain code fences instead.
+
+```yaml
+code_copy_button: true
+```
+
 ### `recent-tools-expanded`
 
 - **Type:** `integer`

--- a/tests/test_copyable_fence.py
+++ b/tests/test_copyable_fence.py
@@ -1,0 +1,134 @@
+"""End-to-end tests for the code-block Copy button.
+
+``SafeMarkdown`` swaps Textual's plain code fence for
+``CopyableMarkdownFence``, which renders a header bar (language +
+``⧉ Copy``) above every fenced code block. These tests drive the REAL
+widget path in a mounted Textual app: they confirm the copyable fence is
+what actually renders, that clicking the button copies the block's raw
+source (not the syntax-highlighted content), and that a fence updated
+mid-stream copies the *updated* source rather than its first-seen text.
+"""
+
+from __future__ import annotations
+
+import pytest
+from claudechic.widgets.content.safe_markdown import (
+    CopyableMarkdownFence,
+    SafeMarkdown,
+)
+from claudechic.widgets.primitives.button import Button
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+from textual.widgets._markdown import MarkdownFence
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.timeout(30)]
+
+CODE = "uv tool install claudechic\nclaudechic --yolo"
+DOC = f"Here is how to install it:\n\n```bash\n{CODE}\n```\n"
+
+
+class _HostApp(App):
+    """Minimal app hosting a SafeMarkdown; records clipboard writes."""
+
+    def __init__(self, markdown: str) -> None:
+        super().__init__()
+        self._markdown = markdown
+        self.copied: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield SafeMarkdown(self._markdown)
+
+    def copy_to_clipboard(self, text: str) -> None:  # type: ignore[override]
+        # Record instead of touching the real system clipboard / OSC-52.
+        self.copied.append(text)
+
+
+async def test_fence_renders_as_copyable_with_header():
+    """A fenced code block renders as CopyableMarkdownFence with a header
+    showing the language and a Copy button."""
+    app = _HostApp(DOC)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        fence = app.query_one(CopyableMarkdownFence)
+        assert fence.code.strip() == CODE
+
+        # Language label reflects the fence info string.
+        assert fence.lexer == "bash"
+        lang = fence.query_one(".fence-lang", Static)
+        assert "bash" in str(lang.render())
+
+        # Exactly one Copy button, inside the fence.
+        button = fence.query_one(".fence-copy", Button)
+        assert button is not None
+
+
+async def test_clicking_copy_button_copies_raw_code():
+    """Clicking the Copy button copies the block's raw source verbatim."""
+    app = _HostApp(DOC)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        button = app.query_one(".fence-copy", Button)
+        await pilot.click(button)
+        await pilot.pause()
+
+        assert app.copied, "Copy button click should have copied something"
+        assert app.copied[-1].strip() == CODE
+        # Highlighting artifacts must not leak in -- raw source only.
+        assert "\x1b" not in app.copied[-1]
+
+
+async def test_copy_reflects_streamed_update():
+    """A fence updated mid-stream copies the UPDATED source, not the
+    first-seen text (guards the self.code refresh in _update_from_block)."""
+    app = _HostApp(DOC)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        fence = app.query_one(CopyableMarkdownFence)
+
+        # Simulate what MarkdownStream does on a later token: build a fresh
+        # fence carrying new source and fold it into the mounted one.
+        new_code = "echo updated"
+        replacement = CopyableMarkdownFence(fence._markdown, fence._token, new_code)
+        await fence._update_from_block(replacement)
+
+        assert fence.code == new_code
+
+        await pilot.click(app.query_one(".fence-copy", Button))
+        await pilot.pause()
+        assert app.copied[-1] == new_code
+
+
+async def test_copy_failure_notifies_and_does_not_raise():
+    """If copy_to_clipboard raises, the click is swallowed with an error
+    toast rather than crashing the TUI."""
+
+    class _BrokenApp(_HostApp):
+        def copy_to_clipboard(self, text: str) -> None:  # type: ignore[override]
+            raise RuntimeError("clipboard unavailable")
+
+    app = _BrokenApp(DOC)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Should not raise out of the event loop.
+        await pilot.click(app.query_one(".fence-copy", Button))
+        await pilot.pause()
+
+
+async def test_disabled_config_renders_plain_fence(monkeypatch):
+    """With code_copy_button=False, fences render as the plain Textual
+    MarkdownFence with no Copy button."""
+    from claudechic import config
+
+    monkeypatch.setitem(config.CONFIG, "code_copy_button", False)
+
+    app = _HostApp(DOC)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        # No copyable fence, no copy button; still a code fence present.
+        assert not app.query(CopyableMarkdownFence)
+        assert not app.query(".fence-copy")
+        assert app.query(MarkdownFence), "a plain code fence should still render"


### PR DESCRIPTION
### What
Adds a header bar above every fenced/indented code block in agent output — language on the left, a `⧉ Copy` button on the right. Clicking copies the block's **raw source** to the clipboard.

### Why
Terminal commands and snippets are the thing users most often want to lift out of an answer. Today that means click-dragging a selection across a syntax-highlighted, horizontally-scrolling block and hoping you didn't grab a stray backtick or prompt character. A button copies exactly the source markdown-it parsed — nothing else. (Complements, not replaces, the existing Ctrl+Y/Ctrl+C selection copy.)

### How
`SafeMarkdown` swaps Textual's fence widget for a `CopyableMarkdownFence` via the supported `get_block_class()` hook — no monkey-patching. The button reuses the app's existing `copy_to_clipboard()` (OSC-52 + platform fallbacks). `self.code` is refreshed on every streaming update so copies stay correct while an answer is still writing.

### Config / opt-out
New `code_copy_button` (default `true`), exposed in `/settings` and documented in `docs/configuration.md`. Set `false` to render plain fences.

### Testing
5 new end-to-end tests drive the real widget in a mounted app (pilot clicks): renders-as-copyable, click-copies-raw-source, streamed-update-copies-fresh-text, copy-failure-doesn't-crash, disabled-config-renders-plain-fence. Full suite: no new failures (9 pre-existing symlink failures are Windows-env, unrelated). ruff + pyright clean.

### Notes
- Targets `main` (where recent PRs land). No `.project_team/` paths.
- Because `SafeMarkdown` backs all rendered content, buttons also appear on code blocks in tool output / plan panels — intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)